### PR TITLE
Updated 8tracks strategy to make play button work on newly-loaded pages

### DIFF
--- a/BeardedSpice/EightTracksStrategy.m
+++ b/BeardedSpice/EightTracksStrategy.m
@@ -26,7 +26,7 @@
 
 -(NSString *) toggle
 {
-    return @"(function(){window.mixPlayer.toggle()})()";
+    return @"(function(){window.mixPlayer?window.mixPlayer.toggle():document.querySelector('#play_overlay').click()})()";
 }
 
 -(NSString *) previous


### PR DESCRIPTION
When an 8tracks page first loads, the global `mixPlayer` object doesn't exist. This PR scripts clicking the play button when there's no mixPlayer
