### PR TITLE
Make previous and next work on Overcast.fm

### DIFF
--- a/BeardedSpice/OvercastStrategy.m
+++ b/BeardedSpice/OvercastStrategy.m
@@ -26,7 +26,17 @@
 
 -(NSString *) toggle
 {
-    return @"var p=document.getElementById('audioplayer'); if(p.paused){ p.play();}else{p.pause();}";
+    return @"var p=document.getElementById('audioplayer'); if(p.paused){p.play();}else{p.pause();}";
+}
+
+-(NSString *) previous
+{
+    return @"var p=document.getElementById('audioplayer'); p.currentTime=p.currentTime-15;";
+}
+
+-(NSString *) next
+{
+    return @"var p=document.getElementById('audioplayer'); p.currentTime=p.currentTime+30;";
 }
 
 -(NSString *) displayName


### PR DESCRIPTION
It uses sensible defaults, in line with the iOS app. Previous goes back 15 seconds, while forward advances 30 seconds.
