### PR TITLE
Added code to translate headset volume events into system volume events

### DIFF
--- a/BeardedSpice.xcodeproj/project.pbxproj
+++ b/BeardedSpice.xcodeproj/project.pbxproj
@@ -627,10 +627,8 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
+					"$(PROJECT_DIR)",
 					"$(inherited)",
-					/Users/trhodes/workspace/beardedspice,
-					/Users/trhodes/workspace/DDHidLib/build/Release,
-					"/Users/trhodes/workspace/personal/bearded-spice",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "BeardedSpice/BeardedSpice-Prefix.pch";
@@ -649,10 +647,8 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
+					"$(PROJECT_DIR)",
 					"$(inherited)",
-					/Users/trhodes/workspace/beardedspice,
-					/Users/trhodes/workspace/DDHidLib/build/Release,
-					"/Users/trhodes/workspace/personal/bearded-spice",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "BeardedSpice/BeardedSpice-Prefix.pch";

--- a/BeardedSpice/AppDelegate.m
+++ b/BeardedSpice/AppDelegate.m
@@ -356,10 +356,35 @@
                     [activeTab executeJavascript:[strategy next]];
                 }
                 break;
+            case kHIDUsage_GD_SystemMenuUp:
+                [self pressKey:NX_KEYTYPE_SOUND_UP];
+                break;
+            case kHIDUsage_GD_SystemMenuDown:
+                [self pressKey:NX_KEYTYPE_SOUND_DOWN];
+                break;
             default:
                 NSLog(@"Unknown key press seen %d", usageId);
         }
     }
+}
+
+- (void)pressKey:(NSUInteger)keytype {
+    [self keyEvent:keytype state:0xA];  // key down
+    [self keyEvent:keytype state:0xB];  // key up
+}
+
+- (void)keyEvent:(NSUInteger)keytype state:(NSUInteger)state {
+    NSEvent *event = [NSEvent otherEventWithType:NSSystemDefined
+                                        location:NSZeroPoint
+                                   modifierFlags:(state << 2)
+                                       timestamp:0
+                                    windowNumber:0
+                                         context:nil
+                                         subtype:0x8
+                                           data1:(keytype << 16) | (state << 8)
+                                           data2:-1];
+
+    CGEventPost(0, [event CGEvent]);
 }
 
 @end


### PR DESCRIPTION
Based on code from here:
http://stackoverflow.com/questions/11045814/emulate-media-key-press-on-mac

I had to change the hardcoded framework search paths to get it to compile, hopefully it didn't break compiling for everyone else
