### PR TITLE
Improved menu load time

### DIFF
--- a/BeardedSpice/AppDelegate.m
+++ b/BeardedSpice/AppDelegate.m
@@ -110,11 +110,15 @@
     [self removeAllItems];
     [self refreshApplications];
 
+    [mediaStrategyRegistry beginStrategyQueries];
+
     [self refreshTabsForChrome:chromeApp];
     [self refreshTabsForChrome:canaryApp];
     [self refreshTabsForSafari:safariApp];
 
-    
+    [mediaStrategyRegistry endStrategyQueries];
+
+
     if ([statusMenu numberOfItems] == 3) {
         NSMenuItem *item = [statusMenu insertItemWithTitle:@"No applicable tabs open :(" action:nil keyEquivalent:@"" atIndex:0];
         [item setEnabled:NO];

--- a/BeardedSpice/MediaStrategyRegistry.h
+++ b/BeardedSpice/MediaStrategyRegistry.h
@@ -25,5 +25,8 @@
 -(MediaStrategy *) getMediaStrategyForTab:(id <Tab>) tab;
 -(NSArray *) getMediaStrategies;
 
+- (void)clearCache;
+- (void)beginStrategyQueries;
+- (void)endStrategyQueries;
 
 @end

--- a/BeardedSpice/MediaStrategyRegistry.m
+++ b/BeardedSpice/MediaStrategyRegistry.m
@@ -34,6 +34,11 @@
 #import "OvercastStrategy.h"
 #import "VimeoStrategy.h"
 
+@interface MediaStrategyRegistry ()
+@property (nonatomic, strong) NSMutableDictionary *registeredCache;
+@property (nonatomic, strong) NSMutableSet *keyCache;
+@end
+
 @implementation MediaStrategyRegistry
 
 -(id) init
@@ -41,7 +46,8 @@
     self = [super init];
     if (self)
     {
-        availableStrategies = [NSMutableArray new];
+        self.registeredCache = [NSMutableDictionary dictionary];
+        availableStrategies = [NSMutableArray array];
     }
     return self;
 }
@@ -83,10 +89,41 @@
     [availableStrategies containsObject:strategy];
 }
 
+- (void)clearCache
+{
+    self.registeredCache = [NSMutableDictionary dictionary];
+}
+
+- (void)beginStrategyQueries
+{
+    self.keyCache = [NSMutableSet setWithArray:[_registeredCache allKeys]];
+}
+
+- (void)endStrategyQueries
+{
+    /* Clean the cache of tabs that dont exist anymore */
+    NSSet *updatedKeys = [NSSet setWithArray:[_registeredCache allKeys]];
+    [_keyCache minusSet:updatedKeys];
+    [_registeredCache removeObjectsForKeys:[_keyCache allObjects]];
+
+    self.keyCache = nil;
+}
+
 -(MediaStrategy *) getMediaStrategyForTab:(id<Tab>)tab
 {
-    for (MediaStrategy *strategy in availableStrategies) {
-        if ([strategy accepts:tab]) {
+    NSString *cacheKey = [NSString stringWithFormat:@"%@", tab.URL];
+    MediaStrategy *strat = _registeredCache[cacheKey];
+    if (strat)
+        /* Return the equivalent of a full scan except we dont repeat calculations */
+        return [strat isKindOfClass:[MediaStrategy class]] ? strat : NULL;
+
+    for (MediaStrategy *strategy in availableStrategies)
+    {
+        BOOL accepted = [strategy accepts:tab];
+
+        /* Store the result of this calculation for future use */
+        _registeredCache[cacheKey] = accepted ? strategy : @NO;
+        if (accepted) {
             NSLog(@"%@ is valid for %@", strategy, tab);
             return strategy;
         }


### PR DESCRIPTION
Added a cache in MediaStrategyRegistry that will cache the results of previous queries. This effectively reduces the scan time from 0.02s per tab to 0.005s on any menu load after the first.

The use of beginStrategyQueries/endStrategyQueries is to allow the cleanup of the cache, removing any entries for tabs that no longer exist.
However, running getMediaStrategyForTab: without the wrapper methods will not cause any issues, only a potential memory bloat over a very long period of time (depending on frequency of menu opens vs number of tab changes).

Also applied some best practices to the overall code structure of MediaStrategyRegistry to ensure it being threadsafe against any future changes.
