### PR TITLE
Pause active tab when the system is going to sleep

### DIFF
--- a/BeardedSpice/AppDelegate.m
+++ b/BeardedSpice/AppDelegate.m
@@ -49,6 +49,7 @@
     [self setupActiveTabShortcutCallback];
     [self setupFavoriteShortcutCallback];
     [self setupNotificationShortcutCallback];
+    [self setupSleepCallback];
     
     // set whether to always show notifications
     alwaysShowNotification = [[[NSUserDefaults standardUserDefaults] objectForKey:BeardedSpiceAlwaysShowNotification] boolValue];
@@ -317,6 +318,23 @@
         if (track) {
             [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:[track asNotification]];
         }
+    }
+}
+
+- (void)setupSleepCallback
+{
+    [[[NSWorkspace sharedWorkspace] notificationCenter]
+     addObserver: self
+     selector: @selector(receiveSleepNote:)
+     name: NSWorkspaceWillSleepNotification object: NULL];
+}
+
+- (void)receiveSleepNote:(NSNotification *)note
+{
+    MediaStrategy *strategy = [mediaStrategyRegistry getMediaStrategyForTab:activeTab];
+    if (strategy) {
+        NSLog(@"Received sleep note, pausing");
+        [activeTab executeJavascript:[strategy pause]];
     }
 }
 


### PR DESCRIPTION
This should be consistent with how iTunes and other music players react to system sleep. It's useful for me (music won't start blasting out when I open the lid at work), maybe useful for others, too.
