### PR TITLE
Activate when opening menu

### DIFF
--- a/BeardedSpice/AppDelegate.m
+++ b/BeardedSpice/AppDelegate.m
@@ -129,6 +129,8 @@
     if ([statusMenu numberOfItems] == 3) {
         NSMenuItem *item = [statusMenu insertItemWithTitle:@"No applicable tabs open :(" action:nil keyEquivalent:@"" atIndex:0];
         [item setEnabled:NO];
+    } else {
+        [[NSApplication sharedApplication] activateIgnoringOtherApps:YES];
     }
 }
 

--- a/BeardedSpice/AppDelegate.m
+++ b/BeardedSpice/AppDelegate.m
@@ -129,8 +129,10 @@
     if ([statusMenu numberOfItems] == 3) {
         NSMenuItem *item = [statusMenu insertItemWithTitle:@"No applicable tabs open :(" action:nil keyEquivalent:@"" atIndex:0];
         [item setEnabled:NO];
+    } else if ([SPMediaKeyTap usesGlobalMediaKeyTap]) {
+        [keyTap startWatchingMediaKeys];
     } else {
-        [[NSApplication sharedApplication] activateIgnoringOtherApps:YES];
+        NSLog(@"Media key monitoring disabled");
     }
 }
 


### PR DESCRIPTION
Allows BeardedSpice to reassert control over the media keys without restarting or opening the preferences.

Makes BeardedSpice the active application when the menu is opened, so that SPMediaKeyTap intercepts the key taps instead of deferring to the next application.