### PR TITLE
Add pod setup to dependencies installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ BeardedSpice is built with [SPMediaKeyTap](https://github.com/nevyn/SPMediaKeyTa
 We use [CocoaPods](http://cocoapods.org/) to manage all obj-c/cocoa dependences. Install them locally using:
 ```bash
 sudo gem install cocoapods
+pod setup
 pod install
 ```
 


### PR DESCRIPTION
`pod setup` step was needed on my laptop when installing the dependencies. Running just `pod install` would give and error complaining that ~/.cocoapods folder did not exist.