### PR TITLE
Added other TLDs for Yandex Music.

### DIFF
--- a/BeardedSpice/YandexMusicStrategy.m
+++ b/BeardedSpice/YandexMusicStrategy.m
@@ -14,7 +14,7 @@
 {
     self = [super init];
     if (self) {
-        predicate = [NSPredicate predicateWithFormat:@"SELF LIKE[c] '*music.yandex.ru*'"];
+        predicate = [NSPredicate predicateWithFormat:@"SELF LIKE[c] '*music.yandex.*'"];
     }
     return self;
 }


### PR DESCRIPTION
Resolves this issue https://github.com/beardedspice/beardedspice/issues/76
Yandex Music is also on .ua, .kz, and .by TLDs, so I decided not to name them all and just put the TLD under wildcard