### PR TITLE
Digitally Imported media strategy

### DIFF
--- a/BeardedSpice.xcodeproj/project.pbxproj
+++ b/BeardedSpice.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		83AAFD7818E0A79500640767 /* StitcherStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = 83AAFD7718E0A79500640767 /* StitcherStrategy.m */; };
 		8C6FC6D2192A09290050F426 /* XboxMusicStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C6FC6D1192A09290050F426 /* XboxMusicStrategy.m */; };
 		8E38FAD61994CE57005C2465 /* VimeoStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E38FAD51994CE57005C2465 /* VimeoStrategy.m */; };
+		95124C641AD0ECB5001B1F3D /* DigitallyImportedStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = 95124C631AD0ECB5001B1F3D /* DigitallyImportedStrategy.m */; };
 		963E89B818BB010600FE0DBB /* MixCloudStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = 963E89B718BB010600FE0DBB /* MixCloudStrategy.m */; };
 		963E89BB18BB05F400FE0DBB /* MusicUnlimitedStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = 963E89BA18BB05F400FE0DBB /* MusicUnlimitedStrategy.m */; };
 		967933301855173100A49AC7 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9679332F1855173100A49AC7 /* Cocoa.framework */; };
@@ -170,6 +171,8 @@
 		8C6FC6D3192A09430050F426 /* XboxMusicStrategy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XboxMusicStrategy.h; sourceTree = "<group>"; };
 		8E38FAD41994CE57005C2465 /* VimeoStrategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VimeoStrategy.h; sourceTree = "<group>"; };
 		8E38FAD51994CE57005C2465 /* VimeoStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VimeoStrategy.m; sourceTree = "<group>"; };
+		95124C621AD0ECB5001B1F3D /* DigitallyImportedStrategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DigitallyImportedStrategy.h; sourceTree = "<group>"; };
+		95124C631AD0ECB5001B1F3D /* DigitallyImportedStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DigitallyImportedStrategy.m; sourceTree = "<group>"; };
 		963E89B618BB010600FE0DBB /* MixCloudStrategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MixCloudStrategy.h; sourceTree = "<group>"; };
 		963E89B718BB010600FE0DBB /* MixCloudStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MixCloudStrategy.m; sourceTree = "<group>"; };
 		963E89B918BB05F400FE0DBB /* MusicUnlimitedStrategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MusicUnlimitedStrategy.h; sourceTree = "<group>"; };
@@ -261,6 +264,8 @@
 		03A34919185E9FC700C4A62B /* MediaStrategies */ = {
 			isa = PBXGroup;
 			children = (
+				95124C621AD0ECB5001B1F3D /* DigitallyImportedStrategy.h */,
+				95124C631AD0ECB5001B1F3D /* DigitallyImportedStrategy.m */,
 				503E32DA1ACE773000210195 /* NoAdRadioStrategy.h */,
 				503E32DB1ACE773000210195 /* NoAdRadioStrategy.m */,
 				32F131441A71B6090029E9EF /* PocketCastsStrategy.h */,
@@ -599,6 +604,7 @@
 				031D8149187F982A00A93E00 /* RdioStrategy.m in Sources */,
 				0362FF2618552FB300ADA4B4 /* SPMediaKeyTap.m in Sources */,
 				699AAD3F1992C0BE0021BFF2 /* OvercastStrategy.m in Sources */,
+				95124C641AD0ECB5001B1F3D /* DigitallyImportedStrategy.m in Sources */,
 				B500FC3818D33F2E00FEFD74 /* YandexMusicStrategy.m in Sources */,
 				1AAB7F031A3AACE900EC9E2D /* AudioMackStrategy.m in Sources */,
 				963E89BB18BB05F400FE0DBB /* MusicUnlimitedStrategy.m in Sources */,

--- a/BeardedSpice/AppDelegate.h
+++ b/BeardedSpice/AppDelegate.h
@@ -50,6 +50,7 @@ extern BOOL accessibilityApiEnabled;
 }
 
 @property (nonatomic, readonly) NSWindowController *preferencesWindowController;
+@property (nonatomic, strong) NSTimer *autoselectTimer;
 
 - (IBAction)openPreferences:(id)sender;
 - (void)showNotification;

--- a/BeardedSpice/AppDelegate.m
+++ b/BeardedSpice/AppDelegate.m
@@ -91,6 +91,8 @@ BOOL accessibilityApiEnabled = NO;
     
     // check accessibility enabled
     [self checkAccessibilityTrusted];
+    
+    self.autoselectTimer = [NSTimer scheduledTimerWithTimeInterval:3 target:self selector:@selector(refreshTabs:) userInfo:nil repeats:YES];
 }
 
 - (void)awakeFromNib
@@ -522,10 +524,24 @@ BOOL accessibilityApiEnabled = NO;
         NSMenuItem *item = [statusMenu insertItemWithTitle:@"No applicable tabs open :(" action:nil keyEquivalent:@"" atIndex:0];
         [item setEnabled:NO];
     } else if ([SPMediaKeyTap usesGlobalMediaKeyTap]) {
+        NSLog(@"refreshTabs: has extra menu items");
         [keyTap startWatchingMediaKeys];
+        
+        if (!activeTab || ![self isActiveTabStillAvailable]) {
+            NSLog(@"refreshTabs: active tab is unset or expired. need to choose a new one");
+            [self updateActiveTab:(id<Tab>)[[statusMenu itemAtIndex:0] representedObject]];
+        }
     } else {
         NSLog(@"Media key monitoring disabled");
     }
+}
+
+-(BOOL)isActiveTabStillAvailable
+{
+    for (NSMenuItem *item in [statusMenu itemArray]) {
+        if ([item representedObject] == activeTab) return YES;
+    }
+    return NO;
 }
 
 -(void)addChromeStatusMenuItemFor:(ChromeTab *)chromeTab andWindow:(ChromeWindow*)chromeWindow andApplication:(runningSBApplication *)application

--- a/BeardedSpice/DigitallyImportedStrategy.h
+++ b/BeardedSpice/DigitallyImportedStrategy.h
@@ -1,0 +1,17 @@
+//
+//  DigitallyImportedStrategy.h
+//  BeardedSpice
+//
+//  Created by Dennis Lysenko on 4/4/15.
+//  Copyright (c) 2015 Tyler Rhodes / Jose Falcon. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "MediaStrategy.h"
+
+@interface DigitallyImportedStrategy : MediaStrategy
+{
+    NSPredicate *predicate;
+}
+
+@end

--- a/BeardedSpice/DigitallyImportedStrategy.m
+++ b/BeardedSpice/DigitallyImportedStrategy.m
@@ -1,0 +1,54 @@
+//
+//  DigitallyImportedStrategy.m
+//  BeardedSpice
+//
+//  Created by Dennis Lysenko on 4/4/15.
+//  Copyright (c) 2015 Tyler Rhodes / Jose Falcon. All rights reserved.
+//
+
+#import "DigitallyImportedStrategy.h"
+
+@implementation DigitallyImportedStrategy
+
+- (id) init
+{
+    self = [super init];
+    if (self) {
+        predicate = [NSPredicate predicateWithFormat:@"SELF LIKE[c] '*di.fm*'"];
+    }
+    return self;
+}
+
+-(BOOL) accepts:(id <Tab>)tab
+{
+    return [predicate evaluateWithObject:[tab URL]];
+}
+
+-(NSString *) toggle
+{
+    return @"(function(){return document.querySelectorAll('div.controls a')[0].click()})()";
+}
+
+-(NSString *) previous
+{
+    // cannot skip tracks in DI
+    return @"(function(){})()";
+}
+
+-(NSString *) next
+{
+    // cannot skip tracks in DI
+    return @"(function(){})()";
+}
+
+-(NSString *) pause
+{
+    return @"(function(){var pause = document.querySelectorAll('div.controls a')[0];if(pause.classList.contains('icon-pause')){pause.click();}})()";
+}
+
+-(NSString *) displayName
+{
+    return @"Digitally Imported";
+}
+
+@end

--- a/BeardedSpice/MediaStrategyRegistry.m
+++ b/BeardedSpice/MediaStrategyRegistry.m
@@ -42,6 +42,7 @@
 #import "TidalHiFiStrategy.h"
 #import "NoAdRadioStrategy.h"
 #import "SomaFmStrategy.h"
+#import "DigitallyImportedStrategy.h"
 
 @interface MediaStrategyRegistry ()
 @property (nonatomic, strong) NSMutableDictionary *registeredCache;
@@ -184,7 +185,8 @@
                         [PocketCastsStrategy new],
                         [TidalHiFiStrategy new],
                         [NoAdRadioStrategy new],
-                        [SomaFmStrategy new]
+                        [SomaFmStrategy new],
+                        [DigitallyImportedStrategy new]
                     ];
     });
     return strategies;


### PR DESCRIPTION
Added support for DigitallyImported, a streaming radio service for electronic music. Very straightforward as DI does not support skipping tracks. 