### PR TITLE
Fixed Google Music notification issue with HTML special characters

### DIFF
--- a/BeardedSpice/MediaStrategies/GoogleMusicStrategy.m
+++ b/BeardedSpice/MediaStrategies/GoogleMusicStrategy.m
@@ -51,8 +51,13 @@
 
 -(Track *) trackInfo:(TabAdapter *)tab
 {
-   NSDictionary *song = [tab executeJavascript:@"(function(){return {'artist':document.getElementById('player-artist').innerHTML, 'album':document.getElementsByClassName('player-album')[0].innerHTML, 'track':document.getElementById('player-song-title').innerHTML,'image':document.getElementById('playingAlbumArt').getAttribute('src')}})()"];
-
+    NSDictionary *song = [tab executeJavascript:@"(function(){return { \
+                          'track':  document.getElementById('player-song-title').innerText, \
+                          'album':  document.getElementsByClassName('player-album')[0].innerText, \
+                          'artist': document.getElementById('player-artist').innerText, \
+                          'image':  document.getElementById('playingAlbumArt').getAttribute('src')} \
+                          })()"];
+    
     Track *track = [[Track alloc] init];
     track.track = [song objectForKey:@"track"];
     track.album = [song objectForKey:@"album"];


### PR DESCRIPTION
Example:

![image](https://cloud.githubusercontent.com/assets/1910118/7950151/97d18a80-094b-11e5-8b74-30c7c0ce5482.png)

On the JavaScript side, #innerHTML was being used instead of #innerText, which results in special HTML characters things like `&` displayed as `&amp;`