### PR TITLE
Default notification

### DIFF
--- a/BeardedSpice/AppDelegate.m
+++ b/BeardedSpice/AppDelegate.m
@@ -761,7 +761,6 @@ BOOL accessibilityApiEnabled = NO;
         NSLog(@"Show Notofication: %@", track);
     } else if (useFallback) {
         [self showDefaultNotification];
-        NSLog(@"Show Default Notification");
     }
 }
 
@@ -770,17 +769,19 @@ BOOL accessibilityApiEnabled = NO;
     
     if ([activeTab isKindOfClass:[NativeAppTabAdapter class]]) {
         notification.title = [[activeTab class] displayName];
-        notification.informativeText = @"Nothing Playing";
     } else {
         MediaStrategy *strategy =
             [mediaStrategyRegistry getMediaStrategyForTab:activeTab];
         
         notification.title = strategy.displayName;
-        notification.informativeText = @"No track info available";
     }
+    
+    notification.informativeText = @"No track info available";
+
     
     [[NSUserNotificationCenter defaultUserNotificationCenter]
      deliverNotification:notification];
+    NSLog(@"Show Default Notification");
 }
 
 - (void)setupSystemEventsCallback

--- a/BeardedSpice/AppDelegate.m
+++ b/BeardedSpice/AppDelegate.m
@@ -281,7 +281,7 @@ BOOL accessibilityApiEnabled = NO;
     [MASShortcut registerGlobalShortcutWithUserDefaultsKey:BeardedSpiceNotificationShortcut handler:^{
         
         [self autoSelectedTabs];
-        [self showNotification];
+        [self showNotificationUsingFallback:YES];
     }];
 }
 
@@ -738,6 +738,10 @@ BOOL accessibilityApiEnabled = NO;
 }
 
 - (void)showNotification {
+    [self showNotificationUsingFallback:NO];
+}
+
+- (void)showNotificationUsingFallback:(BOOL)useFallback {
     Track *track;
     if ([activeTab isKindOfClass:[NativeAppTabAdapter class]]) {
         if ([activeTab respondsToSelector:@selector(trackInfo)]) {
@@ -755,7 +759,28 @@ BOOL accessibilityApiEnabled = NO;
         [[NSUserNotificationCenter defaultUserNotificationCenter]
             deliverNotification:[track asNotification]];
         NSLog(@"Show Notofication: %@", track);
+    } else if (useFallback) {
+        [self showDefaultNotification];
+        NSLog(@"Show Default Notification");
     }
+}
+
+- (void)showDefaultNotification {
+    NSUserNotification *notification = [[NSUserNotification alloc] init];
+    
+    if ([activeTab isKindOfClass:[NativeAppTabAdapter class]]) {
+        notification.title = [[activeTab class] displayName];
+        notification.informativeText = @"Nothing Playing";
+    } else {
+        MediaStrategy *strategy =
+            [mediaStrategyRegistry getMediaStrategyForTab:activeTab];
+        
+        notification.title = strategy.displayName;
+        notification.informativeText = @"No track info available";
+    }
+    
+    [[NSUserNotificationCenter defaultUserNotificationCenter]
+     deliverNotification:notification];
 }
 
 - (void)setupSystemEventsCallback


### PR DESCRIPTION
If a notification is requested but the current strategy doesn't provide track info, nothing is shown. This is fine when controlling the player, but unexpected (for the user) when explicitly pressing the Track Info hotkey.

This PR adds a default notification to be used as a fallback when the app is unable to get track info (unsupported by current strategy, or nothing playing in the current native app). It only gets triggered on the notification hotkey callback - all other keys continue to show no notification.

![bs-notification](https://cloud.githubusercontent.com/assets/1088234/8191042/2b2614c0-1434-11e5-9bf6-1f07c5c5321f.png)
