### PR TITLE
Added trackInfo for Soundcloud

### DIFF
--- a/BeardedSpice/MediaStrategies/SoundCloudStrategy.m
+++ b/BeardedSpice/MediaStrategies/SoundCloudStrategy.m
@@ -54,4 +54,22 @@
     return @"SoundCloud";
 }
 
+-(Track *) trackInfo:(TabAdapter *)tab
+{
+    NSDictionary *song = [tab executeJavascript:@"(function(){return { \
+                          'track':  document.querySelector('a.playbackSoundBadge__title.sc-truncate').title, \
+                          'album':  document.querySelector('a.playbackSoundBadge__title.sc-truncate').href.split('/')[3], \
+                          'artist': '', \
+                          'image':  document.querySelector('span.sc-artwork.sc-artwork-placeholder-0.image__full').style['background-image'].slice(4, -1)} \
+                          })()"];
+    
+    Track *track = [[Track alloc] init];
+    track.track = [song objectForKey:@"track"];
+    track.album = [song objectForKey:@"album"];
+    track.artist = [song objectForKey:@"artist"];
+    track.image = [self imageByUrlString:song[@"image"]];
+    
+    return track;
+}
+
 @end


### PR DESCRIPTION
We are limited in the track info we can provide for Soundcloud because "Artist" and "Album" are not fields that Soundcloud is aware of. As such, we provide "Track Title" and the "Soundcloud Username" as a pseudo album name. Better than nothing.