### PR TITLE
Updated Wonder fm track info selectors to fix track artist and use available classes

### DIFF
--- a/BeardedSpice/MediaStrategies/WonderFmStrategy.m
+++ b/BeardedSpice/MediaStrategies/WonderFmStrategy.m
@@ -53,8 +53,8 @@
 -(Track *) trackInfo:(TabAdapter *)tab
 {
   Track *track = [[Track alloc] init];
-  [track setTrack:[tab executeJavascript:@"document.querySelector('.current_url').text"]];
-  [track setArtist:[tab executeJavascript:@"document.querySelector('#current_track > a').text"]];
+  [track setTrack:[tab executeJavascript:@"document.querySelector('.track_active .track_name > a').text"]];
+  [track setArtist:[tab executeJavascript:@"document.querySelector('.track_active .track_artist > a').text"]];
 
   return track;
 }


### PR DESCRIPTION
* Fixes track artist to display properly (previously duplicated track name due to changes on Wonder side)
* Updated track name selector to use new `track_name` class