### PR TITLE
Add initial Plex Web support.

### DIFF
--- a/BeardedSpice.xcodeproj/project.pbxproj
+++ b/BeardedSpice.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		17C5B63C18DB3649006F38C1 /* beard-highlighted@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 17C5B63B18DB3649006F38C1 /* beard-highlighted@2x.png */; };
 		1AAB7F031A3AACE900EC9E2D /* AudioMackStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AAB7F021A3AACE900EC9E2D /* AudioMackStrategy.m */; };
 		23AAA028533E406E8D5AFF02 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2299BC537DEC481A9540F7CA /* libPods.a */; };
+		2B0FAF3B1B8612D900E80E4F /* PlexWebStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B0FAF3A1B8612D900E80E4F /* PlexWebStrategy.m */; };
 		32F131461A71B6090029E9EF /* PocketCastsStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = 32F131451A71B6090029E9EF /* PocketCastsStrategy.m */; };
 		377A17A11A5C858C005595E5 /* DeezerStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = 377A17A01A5C858C005595E5 /* DeezerStrategy.m */; };
 		3B0F61291AD5CC6900DADAC2 /* BeatguideStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B0F61271AD5CC6900DADAC2 /* BeatguideStrategy.m */; };
@@ -176,6 +177,8 @@
 		1AAB7F021A3AACE900EC9E2D /* AudioMackStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AudioMackStrategy.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		21D5956B688103BAC9238102 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		2299BC537DEC481A9540F7CA /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		2B0FAF391B8612D900E80E4F /* PlexWebStrategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PlexWebStrategy.h; sourceTree = "<group>"; };
+		2B0FAF3A1B8612D900E80E4F /* PlexWebStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PlexWebStrategy.m; sourceTree = "<group>"; };
 		32F131441A71B6090029E9EF /* PocketCastsStrategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PocketCastsStrategy.h; sourceTree = "<group>"; };
 		32F131451A71B6090029E9EF /* PocketCastsStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = PocketCastsStrategy.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		377A179F1A5C858C005595E5 /* DeezerStrategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeezerStrategy.h; sourceTree = "<group>"; };
@@ -437,6 +440,8 @@
 				699AAD3E1992C0BD0021BFF2 /* OvercastStrategy.m */,
 				03A34927185EE58600C4A62B /* PandoraStrategy.h */,
 				03A34928185EE58600C4A62B /* PandoraStrategy.m */,
+				2B0FAF391B8612D900E80E4F /* PlexWebStrategy.h */,
+				2B0FAF3A1B8612D900E80E4F /* PlexWebStrategy.m */,
 				32F131441A71B6090029E9EF /* PocketCastsStrategy.h */,
 				32F131451A71B6090029E9EF /* PocketCastsStrategy.m */,
 				031D8147187F982A00A93E00 /* RdioStrategy.h */,
@@ -813,6 +818,7 @@
 				03F33EF01857E59B00E8F77E /* SafariTabAdapter.m in Sources */,
 				6588CF461B3584A700A3CBAD /* VOXTabAdapter.m in Sources */,
 				EDA824431B0A5C9500B03E23 /* LeTournedisqueStrategy.m in Sources */,
+				2B0FAF3B1B8612D900E80E4F /* PlexWebStrategy.m in Sources */,
 				03A34929185EE58600C4A62B /* PandoraStrategy.m in Sources */,
 				CA5CCF421887FC0700F7C1C3 /* SynologyStrategy.m in Sources */,
 				D2D98CD9197F34BD00941CBD /* BopFm.m in Sources */,

--- a/BeardedSpice/MediaStrategies/PlexWebStrategy.h
+++ b/BeardedSpice/MediaStrategies/PlexWebStrategy.h
@@ -1,0 +1,16 @@
+//
+//  PlexWebStrategy.h
+//  BeardedSpice
+//
+//  Created by Ryan Sullivan on 8/20/15.
+//  Copyright (c) 2015 BeardedSpice. All rights reserved.
+//
+
+#import "MediaStrategy.h"
+
+@interface PlexWebStrategy : MediaStrategy
+{
+    NSPredicate *predicate;
+}
+
+@end

--- a/BeardedSpice/MediaStrategies/PlexWebStrategy.m
+++ b/BeardedSpice/MediaStrategies/PlexWebStrategy.m
@@ -1,0 +1,67 @@
+//
+//  PlexWebStrategy.m
+//  BeardedSpice
+//
+//  Created by Ryan Sullivan on 8/20/15.
+//  Copyright (c) 2015 BeardedSpice. All rights reserved.
+//
+
+#import "PlexWebStrategy.h"
+
+@implementation PlexWebStrategy
+
+- (id)init {
+    self = [super init];
+    if (self) {
+        predicate =
+        [NSPredicate predicateWithFormat:@"SELF LIKE[c] '*:32400/web*' OR SELF LIKE[c] '*app.plex.tv/web/app*'"];
+    }
+    return self;
+}
+
+
+- (BOOL)accepts:(TabAdapter *)tab {
+    return [predicate evaluateWithObject:[tab URL]];
+}
+
+- (BOOL)isPlaying:(TabAdapter *)tab {
+    NSNumber *value = [tab executeJavascript:@"document.querySelector('.player .pause-btn').classList.contains('hidden')"];
+    return [value boolValue];
+}
+
+- (NSString *)toggle {
+    return @"document.querySelector('.player .'+(document.querySelector('.player .pause-btn').classList.contains('hidden') ? 'play' : 'pause')+'-btn').click()";
+}
+
+- (NSString *)previous {
+    return @"document.querySelector('.player .previous-btn').click()";
+}
+
+- (NSString *)next {
+    return @"document.querySelector('.player .next-btn').click()";
+}
+
+- (NSString *)pause {
+    return @"document.querySelector('.player .pause-btn').click()";
+}
+
+- (NSString *)displayName {
+    return @"Plex Web";
+}
+
+//- (NSString *)favorite {
+//}
+
+//- (Track *)trackInfo:(TabAdapter *)tab {
+//
+//    NSString *infoArtist = [tab executeJavascript:@"return document.querySelector('.player .media-title .grandparent-title-container').innerText"];
+//    NSString *infoTrack = [tab executeJavascript:@"return document.querySelector('.player .media-title .title-container').innerText"];
+//
+//    Track *track = [Track new];
+//    track.artist = infoArtist;
+//    track.track = infoTrack;
+//
+//    return track;
+//}
+
+@end

--- a/BeardedSpice/MediaStrategyRegistry.m
+++ b/BeardedSpice/MediaStrategyRegistry.m
@@ -58,6 +58,7 @@
 #import "IndieShuffleStrategy.h"
 #import "LeTournedisqueStrategy.h"
 #import "ComposedStrategy.h"
+#import "PlexWebStrategy.h"
 
 @interface MediaStrategyRegistry ()
 @property (nonatomic, strong) NSMutableDictionary *registeredCache;
@@ -216,6 +217,7 @@
                         [BlitzrStrategy new],
                         [IndieShuffleStrategy new],
                         [LeTournedisqueStrategy new],
+                        [PlexWebStrategy new],
                         [ComposedStrategy new]
                     ];
     });

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ From the preferences tab, uncheck any types of webpages that you don't want Bear
 - [Odnoklassniki](http://ok.ru)
 - [Overcast.fm](https://overcast.fm)
 - [Pandora](http://pandora.com)
+- [Plex Web](https://app.plex.tv)
 - [Pocket Casts](https://play.pocketcasts.com/)
 - [Rdio](http://rdio.com)
 - [Saavn](http://saavn.com)


### PR DESCRIPTION
This adds initial support for Plex. I reached out to see if there is a better way to handle this than just clicking DOM elements, as that could break at any point, but it works.

This fixes #56.

Known issues:

I am experiencing problems when I have 2 Plex Web windows open at
the same time. However, in normal usage I suspect this is more of an
edge-case than anything else.

(I am not convinced this isn't just an issue with BeardedSpice in general anyways)