### PR TITLE
Add Twitch Strategy

### DIFF
--- a/BeardedSpice.xcodeproj/project.pbxproj
+++ b/BeardedSpice.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		969E45721863E5830037226B /* LastFmStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = 969E45711863E5830037226B /* LastFmStrategy.m */; };
 		9A699C4A188B051000BB647E /* SongzaStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A699C49188B051000BB647E /* SongzaStrategy.m */; };
 		9AF442D51886F71400CD7266 /* EightTracksStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = 9AF442D41886F71400CD7266 /* EightTracksStrategy.m */; };
+		A2A680FA1BC18ED90068C6B5 /* TwitchStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = A2A680F91BC18ED90068C6B5 /* TwitchStrategy.m */; settings = {ASSET_TAGS = (); }; };
 		B500FC3818D33F2E00FEFD74 /* YandexMusicStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = B500FC3718D33F2E00FEFD74 /* YandexMusicStrategy.m */; };
 		BB81E6321B8B3AA000F764EB /* NRKStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = BB81E6301B8B3AA000F764EB /* NRKStrategy.m */; };
 		BE0EC59E41539EF7C9368E11 /* YandexRadioStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = BE0EC7F56FEF36DE52081CE1 /* YandexRadioStrategy.m */; };
@@ -303,6 +304,8 @@
 		9A699C49188B051000BB647E /* SongzaStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = SongzaStrategy.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		9AF442D31886F71400CD7266 /* EightTracksStrategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EightTracksStrategy.h; sourceTree = "<group>"; };
 		9AF442D41886F71400CD7266 /* EightTracksStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = EightTracksStrategy.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		A2A680F81BC18ED90068C6B5 /* TwitchStrategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TwitchStrategy.h; sourceTree = "<group>"; };
+		A2A680F91BC18ED90068C6B5 /* TwitchStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TwitchStrategy.m; sourceTree = "<group>"; };
 		B500FC3618D33F2E00FEFD74 /* YandexMusicStrategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YandexMusicStrategy.h; sourceTree = "<group>"; };
 		B500FC3718D33F2E00FEFD74 /* YandexMusicStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = YandexMusicStrategy.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		BB81E6301B8B3AA000F764EB /* NRKStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NRKStrategy.m; sourceTree = "<group>"; };
@@ -477,6 +480,8 @@
 				4C42172B1B307C2D00B22853 /* TuneInStrategy.m */,
 				D2222A781A180E6900910CFE /* TwentyTwoTracksStrategy.h */,
 				D2222A791A180E6900910CFE /* TwentyTwoTracksStrategy.m */,
+				A2A680F81BC18ED90068C6B5 /* TwitchStrategy.h */,
+				A2A680F91BC18ED90068C6B5 /* TwitchStrategy.m */,
 				8E38FAD41994CE57005C2465 /* VimeoStrategy.h */,
 				8E38FAD51994CE57005C2465 /* VimeoStrategy.m */,
 				81DA43D51950BF55000E98AC /* VkStrategy.h */,
@@ -822,6 +827,7 @@
 				523F839F189747DF007F2FFD /* BeatsMusicStrategy.m in Sources */,
 				03A3491C185EA03300C4A62B /* MediaStrategy.m in Sources */,
 				03F33EF01857E59B00E8F77E /* SafariTabAdapter.m in Sources */,
+				A2A680FA1BC18ED90068C6B5 /* TwitchStrategy.m in Sources */,
 				6588CF461B3584A700A3CBAD /* VOXTabAdapter.m in Sources */,
 				EDA824431B0A5C9500B03E23 /* LeTournedisqueStrategy.m in Sources */,
 				2B0FAF3B1B8612D900E80E4F /* PlexWebStrategy.m in Sources */,

--- a/BeardedSpice/BeardedSpiceUserDefaults.plist
+++ b/BeardedSpice/BeardedSpiceUserDefaults.plist
@@ -80,6 +80,8 @@
 		<true/>
 		<key>TIDAL</key>
 		<true/>
+		<key>Twitch</key>
+		<true/>
 		<key>VK</key>
 		<true/>
 		<key>Vimeo</key>

--- a/BeardedSpice/MediaStrategies/TwitchStrategy.h
+++ b/BeardedSpice/MediaStrategies/TwitchStrategy.h
@@ -1,0 +1,16 @@
+//
+//  TwitchStrategy.h
+//  BeardedSpice
+//
+//  Created by Semyon Perepelitsa on 04.10.15.
+//  Copyright © 2015 BeardedSpice. All rights reserved.
+//
+
+#import "MediaStrategy.h"
+
+@interface TwitchStrategy : MediaStrategy
+{
+    NSPredicate *predicate;
+}
+
+@end

--- a/BeardedSpice/MediaStrategies/TwitchStrategy.m
+++ b/BeardedSpice/MediaStrategies/TwitchStrategy.m
@@ -29,7 +29,7 @@
 
 -(BOOL)isPlaying:(TabAdapter *)tab {
     NSNumber *value =
-        [tab executeJavascript: @"return !$('.player').data('paused')"];
+        [tab executeJavascript: @"return $('.player[data-paused=\"false\"]').length"];
     return [value boolValue];
 }
 

--- a/BeardedSpice/MediaStrategies/TwitchStrategy.m
+++ b/BeardedSpice/MediaStrategies/TwitchStrategy.m
@@ -1,0 +1,43 @@
+//
+//  TwitchStrategy.m
+//  BeardedSpice
+//
+//  Created by Semyon Perepelitsa on 04.10.15.
+//  Copyright © 2015 BeardedSpice. All rights reserved.
+//
+
+#import "TwitchStrategy.h"
+
+@implementation TwitchStrategy
+
+-(id)init {
+    self = [super init];
+    if (self) {
+        predicate =
+        [NSPredicate predicateWithFormat:@"SELF LIKE[c] '*twitch.tv*'"];
+    }
+    return self;
+}
+
+-(NSString *)displayName {
+    return @"Twitch";
+}
+
+- (BOOL)accepts:(TabAdapter *)tab {
+    return [predicate evaluateWithObject:[tab URL]];
+}
+
+-(BOOL)isPlaying:(TabAdapter *)tab {
+    NSNumber *value =
+        [tab executeJavascript: @"return !$('.player').data('paused')"];
+    return [value boolValue];
+}
+
+- (NSString *)toggle {
+    return @"$('.js-control-playpause-button').click()";
+}
+
+- (NSString *)pause {
+    return @"$('.player[data-paused=\"false\"] .js-control-playpause-button').click()";
+}
+@end

--- a/BeardedSpice/MediaStrategyRegistry.m
+++ b/BeardedSpice/MediaStrategyRegistry.m
@@ -60,6 +60,7 @@
 #import "ComposedStrategy.h"
 #import "PlexWebStrategy.h"
 #import "NRKStrategy.h"
+#import "TwitchStrategy.h"
 
 @interface MediaStrategyRegistry ()
 @property (nonatomic, strong) NSMutableDictionary *registeredCache;
@@ -220,6 +221,7 @@
                         [LeTournedisqueStrategy new],
                         [PlexWebStrategy new],
                         [ComposedStrategy new],
+                        [TwitchStrategy new],
                         [NRKStrategy new]
                     ];
     });


### PR DESCRIPTION
#210

[Twitch](http://www.twitch.tv) hosts live streams so only play/pause is required. I have tested all these scripts in Web Console. Unfortunately, I was unable to test the app itself. It does not recognize any players, even iTunes. Not sure if the master has some issues or it's something related to my setup. Here is the console output just in case.

<img width="258" alt="screen shot 2015-10-04 at 20 50 22" src="https://cloud.githubusercontent.com/assets/347921/10269236/8e014cc6-6ad9-11e5-8a3f-63840124744c.png">

```
2015-10-04 20:34:53.686 BeardedSpice[37490:2993902] Reset Mikeys
2015-10-04 20:34:53.721 BeardedSpice[37490:2993902] -[__NSCFString ddhid_unsignedIntForString:]: unrecognized selector sent to instance 0x6000000836b0
2015-10-04 20:34:53.721 BeardedSpice[37490:2993902] -[__NSCFString ddhid_unsignedIntForString:]: unrecognized selector sent to instance 0x6000000836b0
2015-10-04 20:34:56.135 BeardedSpice[37490:2993902] Refreshing tabs...
2015-10-04 20:34:56.136 BeardedSpice[37490:2993902] App com.apple.Safari is running <NSRunningApplication: 0x618000101440 (com.apple.Safari - 36548)>
2015-10-04 20:34:56.184 BeardedSpice[37490:2993902] App com.apple.Safari is running <NSRunningApplication: 0x600000100870 (com.apple.Safari - 36548)>
2015-10-04 20:34:56.199 BeardedSpice[37490:2993902] Reset Media Keys.
2015-10-04 20:34:56.199 BeardedSpice[37490:2993902] Reset Media Keys.
2015-10-04 20:34:57.183 BeardedSpice[37490:2993902] Bartender: Loaded BartenderHelperNinetySix
2015-10-04 20:49:08.826 BeardedSpice[37490:2993902] Refreshing tabs...
2015-10-04 20:49:08.828 BeardedSpice[37490:2993902] App com.apple.Safari is running <NSRunningApplication: 0x608000100990 (com.apple.Safari - 36548)>
2015-10-04 20:49:08.877 BeardedSpice[37490:2993902] App com.apple.Safari is running <NSRunningApplication: 0x6000001025b0 (com.apple.Safari - 36548)>
2015-10-04 20:49:08.893 BeardedSpice[37490:2993902] Reset Media Keys.
2015-10-04 20:49:08.893 BeardedSpice[37490:2993902] Reset Media Keys.
```

The build passes with some warnings.

```
BeardedSpice project Group
/Users/sema/Code/clones/beardedspice/BeardedSpice.xcodeproj
/Users/sema/Code/clones/beardedspice/BeardedSpice.xcodeproj Update to recommended settings
BeardedSpice Group
/Users/sema/Code/clones/beardedspice/BeardedSpice/AppDelegate.m
/Users/sema/Code/clones/beardedspice/BeardedSpice/AppDelegate.m:246:18: Case value not in enumerated type 'DDHidAppleRemoteEventIdentifier' (aka 'enum DDHidAppleRemoteEventIdentifier')
/Users/sema/Code/clones/beardedspice/BeardedSpice/Tabs/NativeAppTabAdapter.m
/Users/sema/Code/clones/beardedspice/BeardedSpice/Tabs/NativeAppTabAdapter.m:12:17: Method definition for 'toggle' not found
/Users/sema/Code/clones/beardedspice/BeardedSpice/Tabs/NativeAppTabAdapter.m:12:17: Method definition for 'pause' not found
/Users/sema/Code/clones/beardedspice/BeardedSpice/Tabs/NativeAppTabAdapter.m:12:17: Method definition for 'next' not found
/Users/sema/Code/clones/beardedspice/BeardedSpice/Tabs/NativeAppTabAdapter.m:12:17: Method definition for 'previous' not found
/Users/sema/Code/clones/beardedspice/BeardedSpice/Tabs/NativeAppTabAdapter.m:12:17: Method definition for 'favorite' not found
/Users/sema/Code/clones/beardedspice/BeardedSpice/Tabs/NativeAppTabAdapter.m:12:17: Method definition for 'trackInfo' not found
/Users/sema/Code/clones/beardedspice/BeardedSpice/Tabs/NativeAppTabAdapter.m:12:17: Method definition for 'isPlaying' not found
/Users/sema/Code/clones/beardedspice/BeardedSpice/MediaStrategy.m
/Users/sema/Code/clones/beardedspice/BeardedSpice/MediaStrategy.m:54:17: Method definition for 'isPlaying:' not found
/Users/sema/Code/clones/beardedspice/BeardedSpice/Preferences/MediaControllerObject.m
/Users/sema/Code/clones/beardedspice/BeardedSpice/Preferences/MediaControllerObject.m:20:125: Undeclared selector 'isPlaying:'
```

I'm using XCode 7.0.1 on OS 10.11