### PR TITLE
Add BBC Radio strategy

### DIFF
--- a/BeardedSpice.xcodeproj/project.pbxproj
+++ b/BeardedSpice.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		BE36E0661A6797B300713BA7 /* FocusAtWillStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = BE36E0651A6797B300713BA7 /* FocusAtWillStrategy.m */; };
 		C31C94181AFB5500003F89AC /* NoonPacificStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = C31C94171AFB5500003F89AC /* NoonPacificStrategy.m */; };
 		CA5CCF421887FC0700F7C1C3 /* SynologyStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = CA5CCF411887FC0700F7C1C3 /* SynologyStrategy.m */; };
+		D00408331C1E2E31006A89D0 /* BBCRadioStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = D00408321C1E2E31006A89D0 /* BBCRadioStrategy.m */; };
 		D055A36A1A7A033E00CE2BBD /* SomaFmStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = D055A3691A7A033E00CE2BBD /* SomaFmStrategy.m */; };
 		D07721661C1439FF004727EF /* NetflixStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = D07721651C1439FF004727EF /* NetflixStrategy.m */; };
 		D07721691C14DF96004727EF /* AudibleStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = D07721681C14DF96004727EF /* AudibleStrategy.m */; };
@@ -348,6 +349,8 @@
 		C31C94171AFB5500003F89AC /* NoonPacificStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NoonPacificStrategy.m; sourceTree = "<group>"; };
 		CA5CCF401887FC0700F7C1C3 /* SynologyStrategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SynologyStrategy.h; sourceTree = "<group>"; };
 		CA5CCF411887FC0700F7C1C3 /* SynologyStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SynologyStrategy.m; sourceTree = "<group>"; };
+		D00408311C1E2E31006A89D0 /* BBCRadioStrategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BBCRadioStrategy.h; sourceTree = "<group>"; };
+		D00408321C1E2E31006A89D0 /* BBCRadioStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BBCRadioStrategy.m; sourceTree = "<group>"; };
 		D055A3691A7A033E00CE2BBD /* SomaFmStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = SomaFmStrategy.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		D055A36B1A7A035200CE2BBD /* SomaFmStrategy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SomaFmStrategy.h; sourceTree = "<group>"; };
 		D07721641C1439FF004727EF /* NetflixStrategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetflixStrategy.h; sourceTree = "<group>"; };
@@ -426,6 +429,8 @@
 		03A34919185E9FC700C4A62B /* MediaStrategies */ = {
 			isa = PBXGroup;
 			children = (
+				D00408311C1E2E31006A89D0 /* BBCRadioStrategy.h */,
+				D00408321C1E2E31006A89D0 /* BBCRadioStrategy.m */,
 				D07721671C14DF96004727EF /* AudibleStrategy.h */,
 				D07721681C14DF96004727EF /* AudibleStrategy.m */,
 				D07721641C1439FF004727EF /* NetflixStrategy.h */,
@@ -923,6 +928,7 @@
 				65163CA91BE60D5A000A3575 /* DDHidElement.m in Sources */,
 				65163CA81BE60D5A000A3575 /* DDHidDevice.m in Sources */,
 				503E32DC1ACE773000210195 /* NoAdRadioStrategy.m in Sources */,
+				D00408331C1E2E31006A89D0 /* BBCRadioStrategy.m in Sources */,
 				65163CAF1BE60D9C000A3575 /* NSDictionary+DDHidExtras.m in Sources */,
 				65E5670B1B768E9E00AD2D46 /* ComposedStrategy.m in Sources */,
 				03A3492F185EE82700C4A62B /* GrooveSharkStrategy.m in Sources */,

--- a/BeardedSpice/BeardedSpiceUserDefaults.plist
+++ b/BeardedSpice/BeardedSpiceUserDefaults.plist
@@ -22,6 +22,8 @@
 		<true/>
 		<key>BandCamp</key>
 		<true/>
+		<key>BBC Radio</key>
+		<true/>
 		<key>Beatguide</key>
 		<true/>
 		<key>Beats Music</key>

--- a/BeardedSpice/MediaStrategies/BBCRadioStrategy.h
+++ b/BeardedSpice/MediaStrategies/BBCRadioStrategy.h
@@ -1,0 +1,16 @@
+//
+//  BBCRadioStrategy.h
+//  BeardedSpice
+//
+//  Created by Max Borghino on 12/13/15.
+//  Copyright (c) 2015 Tyler Rhodes / Jose Falcon. All rights reserved.
+//
+
+#import "MediaStrategy.h"
+
+@interface BBCRadioStrategy : MediaStrategy
+{
+    NSPredicate *predicate;
+}
+
+@end

--- a/BeardedSpice/MediaStrategies/BBCRadioStrategy.m
+++ b/BeardedSpice/MediaStrategies/BBCRadioStrategy.m
@@ -1,0 +1,103 @@
+//
+//  BBCRadioStrategy.m
+//  BeardedSpice
+//
+//  Created by Max Borghino on 12/13/15.
+//  Copyright (c) 2015 Tyler Rhodes / Jose Falcon. All rights reserved.
+//
+
+// strategy/site notes
+// - no previous and next available on site
+
+#import "BBCRadioStrategy.h"
+
+@implementation BBCRadioStrategy
+
+-(id) init
+{
+    self = [super init];
+    if (self) {
+        predicate = [NSPredicate predicateWithFormat:@"SELF LIKE[c] '*bbc.co.uk/radio/player/*'"];
+    }
+    return self;
+}
+
+-(BOOL) accepts:(TabAdapter *)tab
+{
+    return [predicate evaluateWithObject:[tab URL]];
+}
+
+- (BOOL)isPlaying:(TabAdapter *)tab{
+
+    NSNumber *result = [tab executeJavascript:@"\
+                        (function(){\
+                          var s=document.querySelector('#controls');\
+                          return (s && (s.classList.contains('stoppable') || s.classList.contains('pausable')));\
+                        })();"];
+
+    return [result boolValue];
+}
+
+-(NSString *) toggle
+{
+    return @"\
+    (function(){\
+      var s=document.querySelector('#controls'),\
+        play=document.querySelector('#btn-play'),\
+        pause=document.querySelector('#btn-pause');\
+      if (s) { (s.classList.contains('stoppable') || s.classList.contains('pausable')) ? pause.click() : play.click(); }\
+    })();";
+}
+
+- (NSString *)previous {
+    return @"";
+}
+
+- (NSString *)next {
+    return @"";
+}
+
+-(NSString *) pause
+{
+    return @"(function(){document.querySelector('#btn-pause').click();})()";
+}
+
+- (NSString *)favorite
+{
+    return @"(function(){document.querySelector('#toggle-mystations').click();})()";
+}
+
+-(NSString *) displayName
+{
+    return @"BBC Radio";
+}
+
+-(Track *) trackInfo:(TabAdapter *)tab
+{
+    NSDictionary *info = [tab executeJavascript:@"\
+    (function(){\
+      var playlister=document.querySelector('.playlister'),\
+        art, title, artist;\
+      if (playlister) {\
+        art=document.querySelector('.playlister img'),\
+        title=playlister.querySelector('.track .title'),\
+        artist=playlister.querySelector('.track .artist');\
+      } else {\
+        art=document.querySelector('#main-image-wrapper img'),\
+        title=document.querySelector('#parent-title a'),\
+        artist=document.querySelector('#title a');\
+      }\
+      return {'artSrc': art ? art.getAttribute('src') : null,\
+              'title': title ? title.innerText : document.title,\
+              'artist': artist ? artist.innerText : null};\
+    })()"];
+
+    Track *track = [[Track alloc] init];
+    track.track = info[@"title"];
+    track.artist = info[@"artist"];
+    track.image = [self imageByUrlString:info[@"artSrc"]];
+
+    return track;
+}
+
+@end

--- a/BeardedSpice/MediaStrategyRegistry.m
+++ b/BeardedSpice/MediaStrategyRegistry.m
@@ -67,6 +67,7 @@
 #import "MusicForProgrammingStrategy.h"
 #import "NetflixStrategy.h"
 #import "AudibleStrategy.h"
+#import "BBCRadioStrategy.h"
 
 @interface MediaStrategyRegistry ()
 @property (nonatomic, strong) NSMutableDictionary *registeredCache;
@@ -179,6 +180,7 @@
                        [AudibleStrategy new],
                        [AudioMackStrategy new],
                        [BandCampStrategy new],
+                       [BBCRadioStrategy new],
                        [BeatguideStrategy new],
                        [BeatsMusicStrategy new],
                        [BlitzrStrategy new],

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ From the preferences tab, uncheck any types of webpages that you don't want Bear
 - [Audible](http://www.audible.com/)
 - [AudioMack](http://www.audiomack.com/)
 - [BandCamp](http://bandcamp.com)
+- [BBC Radio](http://www.bbc.co.uk/radio)
 - [Beatguide](http://beatguide.me/)
 - [BeatsMusic](http://listen.beatsmusic.com)
 - [Blitzr](http://blitzr.com)


### PR DESCRIPTION
Should support all BBC Radio stations listed at
http://www.bbc.co.uk/radio

This includes Radio 1,2,3,4,5,6, World Service, and about 40 local stations.
Track info uses the site-optional song lister, else falls back to the more
generic show information.

Resolves #194