### PR TITLE
Fixed hang on icon click

### DIFF
--- a/BeardedSpice/AppDelegate.m
+++ b/BeardedSpice/AppDelegate.m
@@ -152,7 +152,12 @@ BOOL accessibilityApiEnabled = NO;
 
 - (void)menuWillOpen:(NSMenu *)menu
 {
-    [self autoSelectedTabs];
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            [self autoSelectedTabs];
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            [self setStatusMenuItemsStatus];
+        });
+    });
     [self setStatusMenuItemsStatus];
 }
 


### PR DESCRIPTION
A small issue is that the bar separating the tabs and the other menu items disappears. This may help with #331 and add on to 4341531a9666a087316e86d1d3b4dc773f71610c.