### PR TITLE
Update Wonder FM strategy to work with Wonder 2.0

### DIFF
--- a/BeardedSpice/MediaStrategies/WonderFmStrategy.m
+++ b/BeardedSpice/MediaStrategies/WonderFmStrategy.m
@@ -26,13 +26,13 @@
 }
 
 - (BOOL)isPlaying:(TabAdapter *)tab{
-    NSNumber *result = [tab executeJavascript:@"(function(){return $('div.jp-audio').hasClass('jp-state-playing');})();"];
+    NSNumber *result = [tab executeJavascript:@"(function(){return document.querySelector('.track--active:not(.track--paused)')})();"];
     return [result boolValue];
 }
 
 -(NSString *) toggle
 {
-    return @"!function(){var e=document.querySelector('.jp-type-single'),l=document.querySelector('a.jp-play'),t=document.querySelector('a.jp-pause'),c=document.querySelector('.track_play'),u='none'===getComputedStyle(e,null).display,n='none'===getComputedStyle(l,null).display;u?c.click():n?t.click():l.click()}();";
+    return @"!function(){document.querySelector('.show--activeTrack .player-play').click()}();";
 }
 
 -(NSString *) previous
@@ -42,31 +42,31 @@
 
 -(NSString *) next
 {
-     return @"(function(){document.querySelector('a.jp-next').click()})()";
+     return @"(function(){document.querySelector('.show--activeTrack .player-skip').click()})();";
 }
 
 -(NSString *) pause
 {
-     return @"(function(){document.querySelector('a.jp-pause').click()})()";
+     return @"(function(){document.querySelector('.show--activeTrack .player-pause').click()})();";
 }
 
 -(NSString *) displayName
 {
-    return @"WonderFM";
+    return @"Wonder FM";
 }
 
 -(Track *) trackInfo:(TabAdapter *)tab
 {
   Track *track = [[Track alloc] init];
-  [track setTrack:[tab executeJavascript:@"document.querySelector('.track_active .track_name > a').text"]];
-  [track setArtist:[tab executeJavascript:@"document.querySelector('.track_active .track_artist > a').text"]];
+  [track setTrack:[tab executeJavascript:@"document.querySelector('.currentTrack .song').text"]];
+  [track setArtist:[tab executeJavascript:@"document.querySelector('.currentTrack .artist').text"]];
 
   return track;
 }
 
 -(NSString *) favorite
 {
-  return @"document.querySelector('.track_active .track_fav').click()";
+  return @"document.querySelector('.track--active .track-fav').click();";
 }
 
 @end

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ From the preferences tab, uncheck any types of webpages that you don't want Bear
 - [Vimeo](https://vimeo.com/)
 - [Vessel](https://www.vessel.com/)
 - [VK ("My Music" from vk.com)](http://vk.com/)
-- [WONDER.FM](http://wonder.fm/)
+- [Wonder FM](http://wonder.fm/)
 - [XboxMusic](http://music.xbox.com)
 - [Yandex Music](https://music.yandex.ru/)
 - [Yandex Radio](https://radio.yandex.ru/)


### PR DESCRIPTION
Wonder.fm launched a redesigned site on 2/17/16. They also launched the Primary (electronic) and White Label (hip hop) sites. This PR updates the Wonder strategy to work with the new site design.

See #359 for the additional support for Primary and White Label strategies.