### PR TITLE
Add VLC app support

### DIFF
--- a/BeardedSpice.xcodeproj/project.pbxproj
+++ b/BeardedSpice.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 		D055A36A1A7A033E00CE2BBD /* SomaFmStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = D055A3691A7A033E00CE2BBD /* SomaFmStrategy.m */; };
 		D07721661C1439FF004727EF /* NetflixStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = D07721651C1439FF004727EF /* NetflixStrategy.m */; };
 		D07721691C14DF96004727EF /* AudibleStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = D07721681C14DF96004727EF /* AudibleStrategy.m */; };
+		D09EFF221C8CD49E00B24DA9 /* VLCTabAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = D09EFF1F1C8CD49E00B24DA9 /* VLCTabAdapter.m */; };
 		D0E89A631C0EB54E0033077D /* MusicForProgrammingStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = D0E89A621C0EB54E0033077D /* MusicForProgrammingStrategy.m */; };
 		D2222A7A1A180E6900910CFE /* TwentyTwoTracksStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = D2222A791A180E6900910CFE /* TwentyTwoTracksStrategy.m */; };
 		D2D98CD9197F34BD00941CBD /* BopFm.m in Sources */ = {isa = PBXBuildFile; fileRef = D2D98CD8197F34BD00941CBD /* BopFm.m */; };
@@ -375,6 +376,9 @@
 		D07721651C1439FF004727EF /* NetflixStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NetflixStrategy.m; sourceTree = "<group>"; };
 		D07721671C14DF96004727EF /* AudibleStrategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AudibleStrategy.h; sourceTree = "<group>"; };
 		D07721681C14DF96004727EF /* AudibleStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AudibleStrategy.m; sourceTree = "<group>"; };
+		D09EFF1F1C8CD49E00B24DA9 /* VLCTabAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VLCTabAdapter.m; sourceTree = "<group>"; };
+		D09EFF201C8CD49E00B24DA9 /* VLCTabAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VLCTabAdapter.h; sourceTree = "<group>"; };
+		D09EFF211C8CD49E00B24DA9 /* VLC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VLC.h; sourceTree = "<group>"; };
 		D0E89A611C0EB54E0033077D /* MusicForProgrammingStrategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MusicForProgrammingStrategy.h; sourceTree = "<group>"; };
 		D0E89A621C0EB54E0033077D /* MusicForProgrammingStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MusicForProgrammingStrategy.m; sourceTree = "<group>"; };
 		D2222A781A180E6900910CFE /* TwentyTwoTracksStrategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TwentyTwoTracksStrategy.h; sourceTree = "<group>"; };
@@ -582,6 +586,9 @@
 		03F33EE31857E21100E8F77E /* Tabs */ = {
 			isa = PBXGroup;
 			children = (
+				D09EFF1F1C8CD49E00B24DA9 /* VLCTabAdapter.m */,
+				D09EFF201C8CD49E00B24DA9 /* VLCTabAdapter.h */,
+				D09EFF211C8CD49E00B24DA9 /* VLC.h */,
 				65C5116C1AED688800EBA6A5 /* Spotify.h */,
 				651967BF1AB3858800B48D3A /* iTunes.h */,
 				6588CF471B358A8300A3CBAD /* VOX.h */,
@@ -942,6 +949,7 @@
 				65163CA71BE60D5A000A3575 /* DDHidAppleRemote.m in Sources */,
 				F72B16AE1BEE2788007B79FA /* HotNewHipHopStrategy.m in Sources */,
 				6537DAAD1AF6E666002F2391 /* SpotifyTabAdapter.m in Sources */,
+				D09EFF221C8CD49E00B24DA9 /* VLCTabAdapter.m in Sources */,
 				50931CA61AEB97B400A38B8E /* WonderFmStrategy.m in Sources */,
 				65C511721AED802B00EBA6A5 /* NativeAppTabAdapter.m in Sources */,
 				8C6FC6D2192A09290050F426 /* XboxMusicStrategy.m in Sources */,

--- a/BeardedSpice/NativeAppTabRegistry.m
+++ b/BeardedSpice/NativeAppTabRegistry.m
@@ -11,20 +11,21 @@
 #import "iTunesTabAdapter.h"
 #import "SpotifyTabAdapter.h"
 #import "VOXTabAdapter.h"
+#import "VLCTabAdapter.h"
 
 @implementation NativeAppTabRegistry
 
 - (id)initWithUserDefaultsKey:(NSString *)defaultsKey{
-    
+
     self = [super init];
     if (self) {
-        
+
         _availableAppClasses = [NSMutableArray array];
         _availableCache = [NSMutableDictionary dictionary];
-        
+
         NSArray *defaultApps = [NativeAppTabRegistry defaultNativeAppClasses];
         NSDictionary *defaults = [[NSUserDefaults standardUserDefaults] dictionaryForKey:defaultsKey];
-        
+
         for (Class appClass in defaultApps) {
             NSString *name = [appClass displayName];
             if (name) {
@@ -45,12 +46,13 @@
 
         [iTunesTabAdapter class],
         [SpotifyTabAdapter class],
+        [VLCTabAdapter class],
         [VOXTabAdapter class]
     ];
 }
 
 - (NSArray *)enabledNativeAppClasses{
-    
+
     @synchronized(self){
     return [_availableAppClasses copy];
     }
@@ -64,18 +66,18 @@
 }
 
 - (void)enableNativeAppClass:(Class)appClass{
-    
+
     @synchronized(self){
-        
+
         [_availableAppClasses addObject:appClass];
         _availableCache[[appClass bundleId]] = appClass;
     }
 }
 
 - (void)disableNativeAppClass:(Class)appClass{
-    
+
     @synchronized(self){
-        
+
         [_availableAppClasses removeObject:appClass];
         [_availableCache removeObjectForKey:[appClass bundleId]];
     }

--- a/BeardedSpice/Tabs/VLC.h
+++ b/BeardedSpice/Tabs/VLC.h
@@ -1,0 +1,250 @@
+/*
+ * VLC.h
+ */
+
+#import <AppKit/AppKit.h>
+#import <ScriptingBridge/ScriptingBridge.h>
+
+
+@class VLCItem, VLCApplication, VLCColor, VLCDocument, VLCWindow, VLCAttributeRun, VLCCharacter, VLCParagraph, VLCText, VLCAttachment, VLCWord, VLCPrintSettings;
+
+enum VLCSavo {
+	VLCSavoAsk = 'ask ' /* Ask the user whether or not to save the file. */,
+	VLCSavoNo = 'no  ' /* Do not save the file. */,
+	VLCSavoYes = 'yes ' /* Save the file. */
+};
+typedef enum VLCSavo VLCSavo;
+
+enum VLCEnum {
+	VLCEnumStandard = 'lwst' /* Standard PostScript error handling */,
+	VLCEnumDetailed = 'lwdt' /* print a detailed report of PostScript errors */
+};
+typedef enum VLCEnum VLCEnum;
+
+@protocol VLCGenericMethods
+
+- (void) closeSaving:(VLCSavo)saving savingIn:(NSURL *)savingIn;  // Close an object.
+- (void) delete;  // Delete an object.
+- (void) duplicateTo:(SBObject *)to withProperties:(NSDictionary *)withProperties;  // Copy object(s) and put the copies at a new location.
+- (BOOL) exists;  // Verify if an object exists.
+- (void) moveTo:(SBObject *)to;  // Move object(s) to a new location.
+- (void) saveAs:(NSString *)as in:(NSURL *)in_;  // Save an object.
+- (void) fullscreen;  // Toggle between fullscreen and windowed mode.
+- (void) GetURL;  // Get a URL
+- (void) mute;  // Mute the audio
+- (void) next;  // Go to the next item in the playlist or the next chapter in the DVD/VCD.
+- (void) OpenURL;  // Open a URL
+- (void) play;  // Start playing the current playlistitem or pause it when it is already playing.
+- (void) previous;  // Go to the previous item in the playlist or the previous chapter in the DVD/VCD.
+- (void) stepBackward;  // Step the current playlist item backward the specified step width (default is 2) (1=extraShort, 2=short, 3=medium, 4=long).
+- (void) stepForward;  // Step the current playlist item forward the specified step width (default is 2) (1=extraShort, 2=short, 3=medium, 4=long).
+- (void) stop;  // Stop playing the current playlistitem
+- (void) volumeDown;  // Bring the volume down by one step. There are 32 steps from 0 to 400% volume.
+- (void) volumeUp;  // Bring the volume up by one step. There are 32 steps from 0 to 400% volume.
+
+@end
+
+
+
+/*
+ * Standard Suite
+ */
+
+// A scriptable object.
+@interface VLCItem : SBObject <VLCGenericMethods>
+
+@property (copy) NSDictionary *properties;  // All of the object's properties.
+
+
+@end
+
+// An application's top level scripting object.
+@interface VLCApplication : SBApplication
+
+- (SBElementArray<VLCDocument *> *) documents;
+- (SBElementArray<VLCWindow *> *) windows;
+
+@property (readonly) BOOL frontmost;  // Is this the frontmost (active) application?
+@property (copy, readonly) NSString *name;  // The name of the application.
+@property (copy, readonly) NSString *version;  // The version of the application.
+
+- (VLCDocument *) open:(NSURL *)x;  // Open an object.
+- (void) print:(NSURL *)x printDialog:(BOOL)printDialog withProperties:(VLCPrintSettings *)withProperties;  // Print an object.
+- (void) quitSaving:(VLCSavo)saving;  // Quit an application.
+
+@end
+
+// A color.
+@interface VLCColor : VLCItem
+
+
+@end
+
+// A document.
+@interface VLCDocument : VLCItem
+
+@property (readonly) BOOL modified;  // Has the document been modified since the last save?
+@property (copy) NSString *name;  // The document's name.
+@property (copy) NSString *path;  // The document's path.
+
+
+@end
+
+// A window.
+@interface VLCWindow : VLCItem
+
+@property NSRect bounds;  // The bounding rectangle of the window.
+@property (readonly) BOOL closeable;  // Whether the window has a close box.
+@property (copy, readonly) VLCDocument *document;  // The document whose contents are being displayed in the window.
+@property (readonly) BOOL floating;  // Whether the window floats.
+- (NSInteger) id;  // The unique identifier of the window.
+@property NSInteger index;  // The index of the window, ordered front to back.
+@property (readonly) BOOL miniaturizable;  // Whether the window can be miniaturized.
+@property BOOL miniaturized;  // Whether the window is currently miniaturized.
+@property (readonly) BOOL modal;  // Whether the window is the application's current modal window.
+@property (copy) NSString *name;  // The full title of the window.
+@property (readonly) BOOL resizable;  // Whether the window can be resized.
+@property (readonly) BOOL titled;  // Whether the window has a title bar.
+@property BOOL visible;  // Whether the window is currently visible.
+@property (readonly) BOOL zoomable;  // Whether the window can be zoomed.
+@property BOOL zoomed;  // Whether the window is currently zoomed.
+
+
+@end
+
+
+
+/*
+ * Text Suite
+ */
+
+// This subdivides the text into chunks that all have the same attributes.
+@interface VLCAttributeRun : VLCItem
+
+- (SBElementArray<VLCAttachment *> *) attachments;
+- (SBElementArray<VLCAttributeRun *> *) attributeRuns;
+- (SBElementArray<VLCCharacter *> *) characters;
+- (SBElementArray<VLCParagraph *> *) paragraphs;
+- (SBElementArray<VLCWord *> *) words;
+
+@property (copy) NSColor *color;  // The color of the first character.
+@property (copy) NSString *font;  // The name of the font of the first character.
+@property NSInteger size;  // The size in points of the first character.
+
+
+@end
+
+// This subdivides the text into characters.
+@interface VLCCharacter : VLCItem
+
+- (SBElementArray<VLCAttachment *> *) attachments;
+- (SBElementArray<VLCAttributeRun *> *) attributeRuns;
+- (SBElementArray<VLCCharacter *> *) characters;
+- (SBElementArray<VLCParagraph *> *) paragraphs;
+- (SBElementArray<VLCWord *> *) words;
+
+@property (copy) NSColor *color;  // The color of the first character.
+@property (copy) NSString *font;  // The name of the font of the first character.
+@property NSInteger size;  // The size in points of the first character.
+
+
+@end
+
+// This subdivides the text into paragraphs.
+@interface VLCParagraph : VLCItem
+
+- (SBElementArray<VLCAttachment *> *) attachments;
+- (SBElementArray<VLCAttributeRun *> *) attributeRuns;
+- (SBElementArray<VLCCharacter *> *) characters;
+- (SBElementArray<VLCParagraph *> *) paragraphs;
+- (SBElementArray<VLCWord *> *) words;
+
+@property (copy) NSColor *color;  // The color of the first character.
+@property (copy) NSString *font;  // The name of the font of the first character.
+@property NSInteger size;  // The size in points of the first character.
+
+
+@end
+
+// Rich (styled) text
+@interface VLCText : VLCItem
+
+- (SBElementArray<VLCAttachment *> *) attachments;
+- (SBElementArray<VLCAttributeRun *> *) attributeRuns;
+- (SBElementArray<VLCCharacter *> *) characters;
+- (SBElementArray<VLCParagraph *> *) paragraphs;
+- (SBElementArray<VLCWord *> *) words;
+
+@property (copy) NSColor *color;  // The color of the first character.
+@property (copy) NSString *font;  // The name of the font of the first character.
+@property NSInteger size;  // The size in points of the first character.
+
+
+@end
+
+// Represents an inline text attachment.  This class is used mainly for make commands.
+@interface VLCAttachment : VLCText
+
+@property (copy) NSString *fileName;  // The path to the file for the attachment
+
+
+@end
+
+// This subdivides the text into words.
+@interface VLCWord : VLCItem
+
+- (SBElementArray<VLCAttachment *> *) attachments;
+- (SBElementArray<VLCAttributeRun *> *) attributeRuns;
+- (SBElementArray<VLCCharacter *> *) characters;
+- (SBElementArray<VLCParagraph *> *) paragraphs;
+- (SBElementArray<VLCWord *> *) words;
+
+@property (copy) NSColor *color;  // The color of the first character.
+@property (copy) NSString *font;  // The name of the font of the first character.
+@property NSInteger size;  // The size in points of the first character.
+
+
+@end
+
+
+
+/*
+ * VLC suite
+ */
+
+// VLC's top level scripting object
+@interface VLCApplication (VLCSuite)
+
+@property NSInteger audioVolume;  // The volume of the current playlist item from 0 to 4, where 4 is 400%
+@property NSInteger currentTime;  // The current time of the current playlist item in seconds.
+@property (readonly) NSInteger durationOfCurrentItem;  // The duration of the current playlist item in seconds.
+@property BOOL fullscreenMode;  // indicates wheter fullscreen is enabled or not
+@property (readonly) BOOL muted;  // Is VLC currently muted?
+@property (copy, readonly) NSString *nameOfCurrentItem;  // Name of the current playlist item.
+@property (copy, readonly) NSString *pathOfCurrentItem;  // Path to the current playlist item.
+@property (readonly) BOOL playing;  // Is VLC playing an item?
+
+@end
+
+
+
+/*
+ * Type Definitions
+ */
+
+@interface VLCPrintSettings : SBObject <VLCGenericMethods>
+
+@property NSInteger copies;  // the number of copies of a document to be printed
+@property BOOL collating;  // Should printed copies be collated?
+@property NSInteger startingPage;  // the first page of the document to be printed
+@property NSInteger endingPage;  // the last page of the document to be printed
+@property NSInteger pagesAcross;  // number of logical pages laid across a physical page
+@property NSInteger pagesDown;  // number of logical pages laid out down a physical page
+@property (copy) NSDate *requestedPrintTime;  // the time at which the desktop printer should print the document
+@property VLCEnum errorHandling;  // how errors are handled
+@property (copy) NSString *faxNumber;  // for fax number
+@property (copy) NSString *targetPrinter;  // for target printer
+
+
+@end
+

--- a/BeardedSpice/Tabs/VLCTabAdapter.h
+++ b/BeardedSpice/Tabs/VLCTabAdapter.h
@@ -1,0 +1,13 @@
+//
+//  VLCTabAdapter.h
+//  BeardedSpice
+//
+//  Created by Max Borghino on 2106-03-06
+//  Copyright (c) 2015 Tyler Rhodes / Jose Falcon. All rights reserved.
+//
+
+#import "NativeAppTabAdapter.h"
+
+@interface VLCTabAdapter : NativeAppTabAdapter
+
+@end

--- a/BeardedSpice/Tabs/VLCTabAdapter.m
+++ b/BeardedSpice/Tabs/VLCTabAdapter.m
@@ -1,0 +1,141 @@
+//
+//  VLCTabAdapter.m
+//  BeardedSpice
+//
+//  Created by Max Borghino on 2106-03-06
+//  Copyright (c) 2015 Tyler Rhodes / Jose Falcon. All rights reserved.
+//
+
+#import "VLCTabAdapter.h"
+#import "VLC.h"
+#import "runningSBApplication.h"
+#import "NSString+Utils.h"
+#import "MediaStrategy.h"
+
+#define APPNAME         @"VLC"
+#define APPID           @"org.videolan.vlc"
+
+@implementation VLCTabAdapter
+
++ (NSString *)displayName{
+
+    return APPNAME;
+}
+
++ (NSString *)bundleId{
+
+    return APPID;
+}
+
+- (NSString *)title {
+
+    @autoreleasepool {
+        VLCApplication *vlc = (VLCApplication *)[self.application sbApplication];
+        NSString *title;
+        if (![NSString isNullOrEmpty:vlc.nameOfCurrentItem])
+            title = vlc.nameOfCurrentItem;
+
+        if ([NSString isNullOrEmpty:title]) {
+            title = NSLocalizedString(@"No Track", @"SpotifyTabAdapter");
+        }
+
+        return [NSString stringWithFormat:@"%@ (%@)", title, APPNAME];
+    }
+}
+- (NSString *)URL{
+
+    return @"VLC";
+}
+
+// We have only one window.
+- (NSString *)key{
+
+    return @"A:VLC";
+}
+
+// We have only one window.
+-(BOOL) isEqual:(__autoreleasing id)otherTab{
+
+    if (otherTab == nil || ![otherTab isKindOfClass:[VLCTabAdapter class]]) return NO;
+
+    return YES;
+}
+
+// try to find the document which will respond to controls
+// NOTE: this feels brittle, it seems there should be a better way
+- (VLCDocument*) activeDocument {
+    VLCDocument *doc = NULL;
+    VLCApplication *vlc = (VLCApplication *)[self.application sbApplication];
+    if (vlc) {
+        NSEnumerator *e = [[vlc windows] objectEnumerator];
+        id o;
+        while ((o = [e nextObject]) && doc == NULL) {
+            NSLog(@"VLC window %@: %lu: %@", o, [o index], [o name]);
+            if ([[o name] isEqualToString: [vlc nameOfCurrentItem]]) {
+                doc = [[[vlc windows] objectAtIndex: [o index]] document];
+            }
+        }
+    }
+    return doc;
+}
+
+//////////////////////////////////////////////////////////////
+#pragma mark Player control methods
+//////////////////////////////////////////////////////////////
+
+- (void)toggle{
+    VLCDocument *doc = [self activeDocument];
+    if (doc) {
+        [doc play];
+    }
+}
+
+- (void)pause{
+    VLCApplication *vlc = (VLCApplication *)[self.application sbApplication];
+    if (vlc && [vlc playing]) {
+        VLCDocument *doc = [self activeDocument];
+        if (doc) {
+            [doc play];
+        }
+    }
+}
+
+- (void)next{
+    VLCDocument *doc = [self activeDocument];
+    if (doc) {
+        [doc next];
+    }
+}
+
+- (void)previous{
+    VLCDocument *doc = [self activeDocument];
+    if (doc) {
+        [doc previous];
+    }
+}
+
+- (Track *)trackInfo{
+    VLCApplication *vlc = (VLCApplication *)[self.application sbApplication];
+    if (vlc) {
+        Track *track = [Track new];
+
+        track.track = [vlc nameOfCurrentItem];
+        track.artist = APPNAME;
+
+        return track;
+    }
+
+    return nil;
+}
+
+- (BOOL)isPlaying{
+
+    VLCApplication *vlc = (VLCApplication *)[self.application sbApplication];
+    if (vlc) {
+        return (BOOL)[vlc playing];
+    }
+
+    return NO;
+}
+
+@end

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ From the preferences tab, uncheck any types of webpages that you don't want Bear
 ### Supported Mac OS X applications
 - [iTunes](http://www.apple.com/itunes/)
 - [Spotify](https://www.spotify.com/)
+- [VLC](http://www.videolan.org/vlc/)
 - [VOX](http://coppertino.com/)
 
 ### Supported Sites


### PR DESCRIPTION
Putting this up for comments as I've never done an app adapter.

The scripting model for VLC has multiple windows and documents, which makes sense. My approach to finding the right object to receive the controls seems hack-ey - I compare the document names against the app's idea of the currently selected media name. Seems to work, but it doesn't make me happy.

@Coder-256 I think you were playing with this too (noticed your question on SO) and I think I ran into exactly the same problems. See what you think of this approach.

@Stillness-2 I think I may have missed something about the API, is there a better way I should be looking through an app's multiple windows? (key() and isEqual() worry me, I should probably be doing something with those eh?) :)

Might address #347  