### PR TITLE
Add dependency injection

### DIFF
--- a/BeardedSpice/AppDelegate.m
+++ b/BeardedSpice/AppDelegate.m
@@ -25,6 +25,8 @@
 
 #import "runningSBApplication.h"
 
+#import <AppleGuice/AppleGuice.h>
+
 /// Because user defaults have good caching mechanism, we can use this macro.
 #define ALWAYSSHOWNOTIFICATION  [[[NSUserDefaults standardUserDefaults] objectForKey:BeardedSpiceAlwaysShowNotification] boolValue]
 
@@ -50,10 +52,17 @@ BOOL accessibilityApiEnabled = NO;
 
 @implementation AppDelegate
 
-
 - (void)dealloc{
     
     [self removeSystemEventsCallback];
+}
+
+/////////////////////////////////////////////////////////////////////////
+#pragma mark - Dependency injection
+/////////////////////////////////////////////////////////////////////////
+
++ (void)initialize {
+    [AppleGuice startServiceWithImplementationDiscoveryPolicy:AppleGuiceImplementationDiscoveryPolicyRuntime];
 }
 
 /////////////////////////////////////////////////////////////////////////

--- a/BeardedSpice/MediaStrategies/AmazonMusicStrategy.h
+++ b/BeardedSpice/MediaStrategies/AmazonMusicStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface AmazonMusicStrategy : MediaStrategy
+@interface AmazonMusicStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/AudibleStrategy.h
+++ b/BeardedSpice/MediaStrategies/AudibleStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface AudibleStrategy : MediaStrategy
+@interface AudibleStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/AudioMackStrategy.h
+++ b/BeardedSpice/MediaStrategies/AudioMackStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface AudioMackStrategy : MediaStrategy
+@interface AudioMackStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/BBCRadioStrategy.h
+++ b/BeardedSpice/MediaStrategies/BBCRadioStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface BBCRadioStrategy : MediaStrategy
+@interface BBCRadioStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/BandCampStrategy.h
+++ b/BeardedSpice/MediaStrategies/BandCampStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface BandCampStrategy : MediaStrategy
+@interface BandCampStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/BeatguideStrategy.h
+++ b/BeardedSpice/MediaStrategies/BeatguideStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface BeatguideStrategy : MediaStrategy
+@interface BeatguideStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/BeatsMusicStrategy.h
+++ b/BeardedSpice/MediaStrategies/BeatsMusicStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface BeatsMusicStrategy : MediaStrategy
+@interface BeatsMusicStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/BlitzrStrategy.h
+++ b/BeardedSpice/MediaStrategies/BlitzrStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface BlitzrStrategy : MediaStrategy
+@interface BlitzrStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/BopFm.h
+++ b/BeardedSpice/MediaStrategies/BopFm.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface BopFm : MediaStrategy
+@interface BopFm : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/BrainFmStrategy.h
+++ b/BeardedSpice/MediaStrategies/BrainFmStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface BrainFmStrategy : MediaStrategy
+@interface BrainFmStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/BugsMusicStrategy.h
+++ b/BeardedSpice/MediaStrategies/BugsMusicStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface BugsMusicStrategy : MediaStrategy
+@interface BugsMusicStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/ChorusStrategy.h
+++ b/BeardedSpice/MediaStrategies/ChorusStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface ChorusStrategy : MediaStrategy
+@interface ChorusStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/ComposedStrategy.h
+++ b/BeardedSpice/MediaStrategies/ComposedStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface ComposedStrategy : MediaStrategy
+@interface ComposedStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/CourseraStrategy.h
+++ b/BeardedSpice/MediaStrategies/CourseraStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface CourseraStrategy : MediaStrategy
+@interface CourseraStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/DailymotionStrategy.h
+++ b/BeardedSpice/MediaStrategies/DailymotionStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface DailymotionStrategy : MediaStrategy
+@interface DailymotionStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/DeezerStrategy.h
+++ b/BeardedSpice/MediaStrategies/DeezerStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface DeezerStrategy : MediaStrategy
+@interface DeezerStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/DigitallyImportedStrategy.h
+++ b/BeardedSpice/MediaStrategies/DigitallyImportedStrategy.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "MediaStrategy.h"
 
-@interface DigitallyImportedStrategy : MediaStrategy
+@interface DigitallyImportedStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/EightTracksStrategy.h
+++ b/BeardedSpice/MediaStrategies/EightTracksStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface EightTracksStrategy : MediaStrategy
+@interface EightTracksStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/FocusAtWillStrategy.h
+++ b/BeardedSpice/MediaStrategies/FocusAtWillStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface FocusAtWillStrategy : MediaStrategy
+@interface FocusAtWillStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/GoogleMusicStrategy.h
+++ b/BeardedSpice/MediaStrategies/GoogleMusicStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface GoogleMusicStrategy : MediaStrategy
+@interface GoogleMusicStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/GrooveSharkStrategy.h
+++ b/BeardedSpice/MediaStrategies/GrooveSharkStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface GrooveSharkStrategy : MediaStrategy
+@interface GrooveSharkStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/HotNewHipHopStrategy.h
+++ b/BeardedSpice/MediaStrategies/HotNewHipHopStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface HotNewHipHopStrategy : MediaStrategy {
+@interface HotNewHipHopStrategy : MediaStrategy <MediaStrategyProtocol> {
     NSPredicate *predicate;
 }
 

--- a/BeardedSpice/MediaStrategies/HypeMachineStrategy.h
+++ b/BeardedSpice/MediaStrategies/HypeMachineStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface HypeMachineStrategy : MediaStrategy
+@interface HypeMachineStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/IndieShuffleStrategy.h
+++ b/BeardedSpice/MediaStrategies/IndieShuffleStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface IndieShuffleStrategy : MediaStrategy
+@interface IndieShuffleStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/JangoMediaStrategy.h
+++ b/BeardedSpice/MediaStrategies/JangoMediaStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface JangoMediaStrategy : MediaStrategy
+@interface JangoMediaStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/KollektFmStrategy.h
+++ b/BeardedSpice/MediaStrategies/KollektFmStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface KollektFmStrategy : MediaStrategy
+@interface KollektFmStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/LastFmStrategy.h
+++ b/BeardedSpice/MediaStrategies/LastFmStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface LastFmStrategy : MediaStrategy
+@interface LastFmStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/LeTournedisqueStrategy.h
+++ b/BeardedSpice/MediaStrategies/LeTournedisqueStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface LeTournedisqueStrategy : MediaStrategy
+@interface LeTournedisqueStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/LogitechMediaServerStrategy.h
+++ b/BeardedSpice/MediaStrategies/LogitechMediaServerStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface LogitechMediaServerStrategy : MediaStrategy
+@interface LogitechMediaServerStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/MixCloudStrategy.h
+++ b/BeardedSpice/MediaStrategies/MixCloudStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface MixCloudStrategy : MediaStrategy
+@interface MixCloudStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/MusicForProgrammingStrategy.h
+++ b/BeardedSpice/MediaStrategies/MusicForProgrammingStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface MusicForProgrammingStrategy : MediaStrategy
+@interface MusicForProgrammingStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/MusicUnlimitedStrategy.h
+++ b/BeardedSpice/MediaStrategies/MusicUnlimitedStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface MusicUnlimitedStrategy : MediaStrategy
+@interface MusicUnlimitedStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/NRKStrategy.h
+++ b/BeardedSpice/MediaStrategies/NRKStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface NRKStrategy : MediaStrategy
+@interface NRKStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/NetflixStrategy.h
+++ b/BeardedSpice/MediaStrategies/NetflixStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface NetflixStrategy : MediaStrategy
+@interface NetflixStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/NoAdRadioStrategy.h
+++ b/BeardedSpice/MediaStrategies/NoAdRadioStrategy.h
@@ -6,7 +6,7 @@
 
 #import "MediaStrategy.h"
 
-@interface NoAdRadioStrategy : MediaStrategy
+@interface NoAdRadioStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/NoonPacificStrategy.h
+++ b/BeardedSpice/MediaStrategies/NoonPacificStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface NoonPacificStrategy : MediaStrategy
+@interface NoonPacificStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/OdnoklassnikiStrategy.h
+++ b/BeardedSpice/MediaStrategies/OdnoklassnikiStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface OdnoklassnikiStrategy : MediaStrategy
+@interface OdnoklassnikiStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/OvercastStrategy.h
+++ b/BeardedSpice/MediaStrategies/OvercastStrategy.h
@@ -9,7 +9,7 @@
 
 #import "MediaStrategy.h"
 
-@interface OvercastStrategy : MediaStrategy
+@interface OvercastStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/PandoraStrategy.h
+++ b/BeardedSpice/MediaStrategies/PandoraStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface PandoraStrategy : MediaStrategy
+@interface PandoraStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/PlexWebStrategy.h
+++ b/BeardedSpice/MediaStrategies/PlexWebStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface PlexWebStrategy : MediaStrategy
+@interface PlexWebStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/PocketCastsStrategy.h
+++ b/BeardedSpice/MediaStrategies/PocketCastsStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface PocketCastsStrategy : MediaStrategy
+@interface PocketCastsStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/RadioSwissJazzStrategy.h
+++ b/BeardedSpice/MediaStrategies/RadioSwissJazzStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface RadioSwissJazzStrategy : MediaStrategy
+@interface RadioSwissJazzStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/RhapsodyStrategy.h
+++ b/BeardedSpice/MediaStrategies/RhapsodyStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface RhapsodyStrategy : MediaStrategy
+@interface RhapsodyStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/SaavnStrategy.h
+++ b/BeardedSpice/MediaStrategies/SaavnStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface SaavnStrategy : MediaStrategy
+@interface SaavnStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/ShufflerFmStrategy.h
+++ b/BeardedSpice/MediaStrategies/ShufflerFmStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface ShufflerFmStrategy : MediaStrategy
+@interface ShufflerFmStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/SlackerStrategy.h
+++ b/BeardedSpice/MediaStrategies/SlackerStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface SlackerStrategy : MediaStrategy
+@interface SlackerStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/SomaFmStrategy.h
+++ b/BeardedSpice/MediaStrategies/SomaFmStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface SomaFmStrategy : MediaStrategy
+@interface SomaFmStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/SoundCloudStrategy.h
+++ b/BeardedSpice/MediaStrategies/SoundCloudStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface SoundCloudStrategy : MediaStrategy
+@interface SoundCloudStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/SpotifyStrategy.h
+++ b/BeardedSpice/MediaStrategies/SpotifyStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface SpotifyStrategy : MediaStrategy
+@interface SpotifyStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/StitcherStrategy.h
+++ b/BeardedSpice/MediaStrategies/StitcherStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface StitcherStrategy : MediaStrategy
+@interface StitcherStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/SubsonicStrategy.h
+++ b/BeardedSpice/MediaStrategies/SubsonicStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface SubsonicStrategy : MediaStrategy
+@interface SubsonicStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/SynologyStrategy.h
+++ b/BeardedSpice/MediaStrategies/SynologyStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface SynologyStrategy : MediaStrategy
+@interface SynologyStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/TidalHiFiStrategy.h
+++ b/BeardedSpice/MediaStrategies/TidalHiFiStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface TidalHiFiStrategy : MediaStrategy{
+@interface TidalHiFiStrategy : MediaStrategy <MediaStrategyProtocol>{
     
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/TuneInStrategy.h
+++ b/BeardedSpice/MediaStrategies/TuneInStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface TuneInStrategy : MediaStrategy
+@interface TuneInStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/TwentyTwoTracksStrategy.h
+++ b/BeardedSpice/MediaStrategies/TwentyTwoTracksStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface TwentyTwoTracksStrategy : MediaStrategy
+@interface TwentyTwoTracksStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/TwitchMediaStrategy.h
+++ b/BeardedSpice/MediaStrategies/TwitchMediaStrategy.h
@@ -1,6 +1,6 @@
 #import "MediaStrategy.h"
 
-@interface TwitchMediaStrategy : MediaStrategy {
+@interface TwitchMediaStrategy : MediaStrategy <MediaStrategyProtocol> {
     
     NSPredicate *predicate;
     

--- a/BeardedSpice/MediaStrategies/UdemyStrategy.h
+++ b/BeardedSpice/MediaStrategies/UdemyStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface UdemyStrategy : MediaStrategy
+@interface UdemyStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/VesselStrategy.h
+++ b/BeardedSpice/MediaStrategies/VesselStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface VesselStrategy : MediaStrategy
+@interface VesselStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/VimeoStrategy.h
+++ b/BeardedSpice/MediaStrategies/VimeoStrategy.h
@@ -9,7 +9,7 @@
 
 #import "MediaStrategy.h"
 
-@interface VimeoStrategy : MediaStrategy
+@interface VimeoStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/VkStrategy.h
+++ b/BeardedSpice/MediaStrategies/VkStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface VkStrategy : MediaStrategy
+@interface VkStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/WatchaPlayStrategy.h
+++ b/BeardedSpice/MediaStrategies/WatchaPlayStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface WatchaPlayStrategy : MediaStrategy
+@interface WatchaPlayStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/WonderFmStrategy.h
+++ b/BeardedSpice/MediaStrategies/WonderFmStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface WonderFmStrategy : MediaStrategy
+@interface WonderFmStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/XboxMusicStrategy.h
+++ b/BeardedSpice/MediaStrategies/XboxMusicStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface XboxMusicStrategy : MediaStrategy
+@interface XboxMusicStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/YandexMusicStrategy.h
+++ b/BeardedSpice/MediaStrategies/YandexMusicStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface YandexMusicStrategy : MediaStrategy
+@interface YandexMusicStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/YandexRadioStrategy.h
+++ b/BeardedSpice/MediaStrategies/YandexRadioStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface YandexRadioStrategy : MediaStrategy
+@interface YandexRadioStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
     NSDictionary *_nextTrackInfo;

--- a/BeardedSpice/MediaStrategies/YouTubeStrategy.h
+++ b/BeardedSpice/MediaStrategies/YouTubeStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface YouTubeStrategy : MediaStrategy
+@interface YouTubeStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategies/iHeartRadioStrategy.h
+++ b/BeardedSpice/MediaStrategies/iHeartRadioStrategy.h
@@ -8,7 +8,7 @@
 
 #import "MediaStrategy.h"
 
-@interface iHeartRadioStrategy : MediaStrategy
+@interface iHeartRadioStrategy : MediaStrategy <MediaStrategyProtocol>
 {
     NSPredicate *predicate;
 }

--- a/BeardedSpice/MediaStrategy.h
+++ b/BeardedSpice/MediaStrategy.h
@@ -7,6 +7,10 @@
 //
 
 #import "TabAdapter.h"
+#import <AppleGuice/AppleGuiceInjectable.h>
+
+@protocol MediaStrategyProtocol <AppleGuiceInjectable>
+@end
 
 @interface Track : NSObject
 

--- a/BeardedSpice/MediaStrategyRegistry.h
+++ b/BeardedSpice/MediaStrategyRegistry.h
@@ -14,8 +14,6 @@
     NSMutableArray *availableStrategies;
 }
 
-+(NSArray *) getDefaultMediaStrategies;
-
 -(id) initWithUserDefaults:(NSString *)userDefaultsKeyPrefix;
 -(void) addMediaStrategy:(MediaStrategy *) strategy;
 -(void) removeMediaStrategy:(MediaStrategy *) strategy;

--- a/BeardedSpice/MediaStrategyRegistry.m
+++ b/BeardedSpice/MediaStrategyRegistry.m
@@ -7,77 +7,11 @@
 //
 
 #import "MediaStrategyRegistry.h"
-#import "LogitechMediaServerStrategy.h"
-#import "YouTubeStrategy.h"
-#import "PandoraStrategy.h"
-#import "CourseraStrategy.h"
-#import "BandCampStrategy.h"
-#import "GrooveSharkStrategy.h"
-#import "SoundCloudStrategy.h"
-#import "HypeMachineStrategy.h"
-#import "LastFmStrategy.h"
-#import "SpotifyStrategy.h"
-#import "GoogleMusicStrategy.h"
-#import "EightTracksStrategy.h"
-#import "SynologyStrategy.h"
-#import "ShufflerFmStrategy.h"
-#import "SlackerStrategy.h"
-#import "BeatsMusicStrategy.h"
-#import "MixCloudStrategy.h"
-#import "MusicUnlimitedStrategy.h"
-#import "YandexMusicStrategy.h"
-#import "StitcherStrategy.h"
-#import "XboxMusicStrategy.h"
-#import "VkStrategy.h"
-#import "BopFm.h"
-#import "AmazonMusicStrategy.h"
-#import "OvercastStrategy.h"
-#import "VimeoStrategy.h"
-#import "ChorusStrategy.h"
-#import "TwentyTwoTracksStrategy.h"
-#import "AudioMackStrategy.h"
-#import "DeezerStrategy.h"
-#import "FocusAtWillStrategy.h"
-#import "PocketCastsStrategy.h"
-#import "YandexRadioStrategy.h"
-#import "TidalHiFiStrategy.h"
-#import "NoAdRadioStrategy.h"
-#import "SomaFmStrategy.h"
-#import "DigitallyImportedStrategy.h"
-#import "BeatguideStrategy.h"
-#import "SaavnStrategy.h"
-#import "KollektFmStrategy.h"
-#import "WonderFmStrategy.h"
-#import "OdnoklassnikiStrategy.h"
-#import "SubsonicStrategy.h"
-#import "TuneInStrategy.h"
-#import "NoonPacificStrategy.h"
-#import "BlitzrStrategy.h"
-#import "IndieShuffleStrategy.h"
-#import "LeTournedisqueStrategy.h"
-#import "ComposedStrategy.h"
-#import "PlexWebStrategy.h"
-#import "NRKStrategy.h"
-#import "UdemyStrategy.h"
-#import "HotNewHipHopStrategy.h"
-#import "JangoMediaStrategy.h"
-#import "RhapsodyStrategy.h"
-#import "MusicForProgrammingStrategy.h"
-#import "NetflixStrategy.h"
-#import "AudibleStrategy.h"
-#import "BBCRadioStrategy.h"
-#import "TwitchMediaStrategy.h"
-#import "iHeartRadioStrategy.h"
-#import "BugsMusicStrategy.h"
-#import "VesselStrategy.h"
-#import "RadioSwissJazzStrategy.h"
-#import "BrainFmStrategy.h"
-#import "WatchaPlayStrategy.h"
-#import "DailymotionStrategy.h"
 
 @interface MediaStrategyRegistry ()
 @property (nonatomic, strong) NSMutableDictionary *registeredCache;
 @property (nonatomic, strong) NSMutableSet *keyCache;
+@property (nonatomic, strong) NSArray *ioc_MediaStrategyProtocol;
 @end
 
 @implementation MediaStrategyRegistry
@@ -97,7 +31,7 @@
 {
     self = [self init];
     if (self) {
-        NSArray *defaultStrategies = [MediaStrategyRegistry getDefaultMediaStrategies];
+        NSArray *defaultStrategies = self.ioc_MediaStrategyProtocol;
         NSDictionary *defaults = [[NSUserDefaults standardUserDefaults] dictionaryForKey:userDefaultsKey];
 
         for (MediaStrategy *strategy in defaultStrategies) {
@@ -175,86 +109,6 @@
 -(NSArray *) getMediaStrategies
 {
     return [availableStrategies copy];
-}
-
-+(NSArray *) getDefaultMediaStrategies
-{
-    static dispatch_once_t setupDefaultStrategies;
-    static NSArray *strategies = nil;
-
-    dispatch_once(&setupDefaultStrategies, ^{
-        NSLog(@"Initializing default media strategies...");
-        strategies = @[
-                       [AmazonMusicStrategy new],
-                       [AudibleStrategy new],
-                       [AudioMackStrategy new],
-                       [BandCampStrategy new],
-                       [BBCRadioStrategy new],
-                       [BeatguideStrategy new],
-                       [BeatsMusicStrategy new],
-                       [BlitzrStrategy new],
-                       [BopFm new],
-                       [BrainFmStrategy new],
-                       [BugsMusicStrategy new],
-                       [ChorusStrategy new],
-                       [ComposedStrategy new],
-                       [CourseraStrategy new],
-                       [DailymotionStrategy new],
-                       [DeezerStrategy new],
-                       [DigitallyImportedStrategy new],
-                       [EightTracksStrategy new],
-                       [FocusAtWillStrategy new],
-                       [GoogleMusicStrategy new],
-                       [GrooveSharkStrategy new],
-                       [HotNewHipHopStrategy new],
-                       [HypeMachineStrategy new],
-                       [iHeartRadioStrategy new],
-                       [IndieShuffleStrategy new],
-                       [JangoMediaStrategy new],
-                       [KollektFmStrategy new],
-                       [LastFmStrategy new],
-                       [LeTournedisqueStrategy new],
-                       [LogitechMediaServerStrategy new],
-                       [MixCloudStrategy new],
-                       [MusicForProgrammingStrategy new],
-                       [MusicUnlimitedStrategy new],
-                       [NetflixStrategy new],
-                       [NoAdRadioStrategy new],
-                       [NoonPacificStrategy new],
-                       [NRKStrategy new],
-                       [OdnoklassnikiStrategy new],
-                       [OvercastStrategy new],
-                       [PandoraStrategy new],
-                       [PlexWebStrategy new],
-                       [PocketCastsStrategy new],
-                       [RadioSwissJazzStrategy new],
-                       [RhapsodyStrategy new],
-                       [SaavnStrategy new],
-                       [ShufflerFmStrategy new],
-                       [SlackerStrategy new],
-                       [SomaFmStrategy new],
-                       [SoundCloudStrategy new],
-                       [SpotifyStrategy new],
-                       [StitcherStrategy new],
-                       [SubsonicStrategy new],
-                       [SynologyStrategy new],
-                       [TidalHiFiStrategy new],
-                       [TuneInStrategy new],
-                       [TwentyTwoTracksStrategy new],
-                       [TwitchMediaStrategy new],
-                       [UdemyStrategy new],
-                       [VesselStrategy new],
-                       [VimeoStrategy new],
-                       [VkStrategy new],
-                       [WatchaPlayStrategy new],
-                       [WonderFmStrategy new],
-                       [XboxMusicStrategy new],
-                       [YandexMusicStrategy new],
-                       [YandexRadioStrategy new],
-                       [YouTubeStrategy new]
-                    ];
-    });
-    return strategies;
 }
 
 @end

--- a/BeardedSpice/Preferences/GeneralPreferencesViewController.m
+++ b/BeardedSpice/Preferences/GeneralPreferencesViewController.m
@@ -22,6 +22,12 @@ NSString *const BeardedSpiceRemoveHeadphonesAutopause = @"BeardedSpiceRemoveHead
 NSString *const BeardedSpiceUsingAppleRemote = @"BeardedSpiceUsingAppleRemote";
 NSString *const BeardedSpiceLaunchAtLogin = @"BeardedSpiceLaunchAtLogin";
 
+@interface GeneralPreferencesViewController()
+
+@property (nonatomic, strong) NSArray* ioc_MediaStrategyProtocol;
+
+@end
+
 @implementation GeneralPreferencesViewController
 
 - (id)initWithMediaStrategyRegistry:(MediaStrategyRegistry *)mediaStrategyRegistry nativeAppTabRegistry:(NativeAppTabRegistry *)nativeAppTabRegistry
@@ -45,7 +51,7 @@ NSString *const BeardedSpiceLaunchAtLogin = @"BeardedSpiceLaunchAtLogin";
             userNativeApps = [NSMutableDictionary dictionaryWithDictionary:[[NSUserDefaults standardUserDefaults] dictionaryForKey:BeardedSpiceActiveNativeAppControllers]];
         }
         
-        theArray = [MediaStrategyRegistry getDefaultMediaStrategies];
+        theArray = self.ioc_MediaStrategyProtocol;
         if (theArray.count) {
             MediaControllerObject *obj = [MediaControllerObject new];
             obj.isGroup = YES;

--- a/Podfile
+++ b/Podfile
@@ -8,5 +8,6 @@ target 'BeardedSpiceControllers' do
 
     target 'BeardedSpice' do
         pod 'MASPreferences', '~> 1.1.2'
+	pod 'AppleGuice', :git => 'https://github.com/arielpollack/AppleGuice'
     end
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,12 +1,24 @@
 PODS:
+  - AppleGuice (1.2.4)
   - MASPreferences (1.1.2)
   - MASShortcut (2.3.3)
 
 DEPENDENCIES:
+  - AppleGuice (from `https://github.com/arielpollack/AppleGuice`)
   - MASPreferences (~> 1.1.2)
   - MASShortcut (~> 2.3.3)
 
+EXTERNAL SOURCES:
+  AppleGuice:
+    :git: https://github.com/arielpollack/AppleGuice
+
+CHECKOUT OPTIONS:
+  AppleGuice:
+    :commit: 8a4e47ce0ac666a7139584fae250e50b144ad23a
+    :git: https://github.com/arielpollack/AppleGuice
+
 SPEC CHECKSUMS:
+  AppleGuice: a631b63c958dffab234824c7296dc06dcf0d08b0
   MASPreferences: 32d8a2c5ef1d60b63240f5676b011ff72e194cb1
   MASShortcut: 38a76c9ea927de770c0a97ae28b15d18d6268b24
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,10 @@ Define these properties of the `Track` object:
 A sample strategy for YandexMusic:
 
 ```Objective-C
+@interface YandexMusicStrategy : MediaStrategy <MediaStrategyProtocol>
+
+@end
+
 @implementation YandexMusicStrategy
 
 - (id)init {
@@ -299,20 +303,6 @@ A sample strategy for YandexMusic:
 }
 
 @end
-```
-
-Update the [`MediaStrategyRegistry`](https://github.com/beardedspice/beardedspice/blob/master/BeardedSpice/MediaStrategyRegistry.m) to include an instance of your new strategy:
-
-```Objective-C
-+(NSArray *) getDefaultMediaStrategies
-{
-        DefaultMediaStrategies = [NSArray arrayWithObjects:
-                                  // ...
-                                  [GoogleMusicStrategy new],
-                                  // add your new strategy!
-                                  [YandexMusicStrategy new],
-                                  nil];
-}
 ```
 
 Finally, update the [default preferences plist](https://github.com/beardedspice/beardedspice/blob/master/BeardedSpice/BeardedSpiceUserDefaults.plist) to include your strategy.


### PR DESCRIPTION
##### Why
For making it easy to add strategies - makes it more decoupled because all strategies are loaded at runtime and not manually.

##### How
Using amazing AppleGuice by Tomer Shiri (https://github.com/tomersh/AppleGuice)

##### Example
In addition to subclassing `MediaStrategy`, conform to the methodless `MediaStrategyProtocol`
```objective-c
@interface YandexMusicStrategy : MediaStrategy <MediaStrategyProtocol>
...
@end
```

##### Note
I've posted a pull-request to AppleGuice for adding support to OSX via cocoapods, so until it will be merged, the podfile links with my fork.