### PR TITLE
Fix Plex tabs and new JS script strategy

### DIFF
--- a/BeardedSpice/BSMediaStrategy.m
+++ b/BeardedSpice/BSMediaStrategy.m
@@ -67,7 +67,7 @@ NSString *const kBSMediaStrategyErrorDomain     = @"kBSMediaStrategyErrorDomain"
     BSMediaStrategy *strategy = [BSMediaStrategy new];
 
     strategy.strategyURL = strategyURL;
-    
+
     strategy.fileName = [[[strategyURL lastPathComponent]
         stringByDeletingPathExtension] stringByAppendingString:@".js"]; // Prevent custom extension, like 'bsstrategy'
 
@@ -92,9 +92,9 @@ NSString *const kBSMediaStrategyErrorDomain     = @"kBSMediaStrategyErrorDomain"
 
 /**
  Copying of the variables, which reflect state of the object.
- 
+
  @param strategy Object from which performed copying.
- 
+
  @return Returns self.
  */
 - (instancetype _Nonnull)copyStateFrom:(BSMediaStrategy * _Nonnull)strategy{
@@ -106,12 +106,12 @@ NSString *const kBSMediaStrategyErrorDomain     = @"kBSMediaStrategyErrorDomain"
     self.fileName = strategy.fileName;
     self.scripts = strategy.scripts;
     self.acceptParams = strategy.acceptParams;
-    
+
     return self;
 }
 
 - (NSComparisonResult)compare:(BSMediaStrategy *)strategy{
-    
+
     return [self.displayName localizedCompare:strategy.displayName];
 }
 
@@ -125,15 +125,15 @@ NSString *const kBSMediaStrategyErrorDomain     = @"kBSMediaStrategyErrorDomain"
 {
     if (!_strategyURL)
         return [self internalError];
-    
+
     NSError *error = nil;
     _strategyJsBody = [[NSString alloc] initWithContentsOfURL:_strategyURL encoding:NSUTF8StringEncoding error:&error];
     if ([NSString isNullOrEmpty:_strategyJsBody])
         return [self internalError];
-    
+
     __block NSError *err = nil;
     JSContext *context = [JSContext new];
-    
+
     // This is run synchronously with evaluateScript :)
     context.exceptionHandler = ^(JSContext __attribute__((unused)) * context,
                                  JSValue * exception) {
@@ -152,7 +152,7 @@ NSString *const kBSMediaStrategyErrorDomain     = @"kBSMediaStrategyErrorDomain"
     JSValue *strategyData = [context evaluateScript:_strategyJsBody];
     if (!err && strategyData.isObject)
         return [self _setupData:strategyData];
-    
+
     return err;
 }
 
@@ -299,7 +299,7 @@ static inline NSString *js_string_for_key(NSString *key, JSValue *node)
     if ([NSString isNullOrEmpty:script]) {
         return NO;
     }
-    
+
     NSNumber *isPlaying = [tab executeJavascript:script];
     return [isPlaying boolValue] ?: NO;
 }
@@ -353,7 +353,7 @@ static inline NSString *js_string_for_key(NSString *key, JSValue *node)
     if ([NSString isNullOrEmpty:script]) {
         return nil;
     }
-    
+
     NSDictionary *trackData = [tab executeJavascript:script];
     return (trackData && trackData.count) ? [[BSTrack alloc] initWithInfo:trackData] : nil;
 }

--- a/BeardedSpice/BSMediaStrategy.m
+++ b/BeardedSpice/BSMediaStrategy.m
@@ -240,7 +240,7 @@ static inline NSString *js_string_for_key(NSString *key, JSValue *node)
     else if ([method isEqualToString:kBSMediaStrategyAcceptScript])
     {
         JSValue *value = acceptJS[kBSMediaStrategyAcceptScript];
-        NSString *acceptScript = [value toString];
+        NSString *acceptScript = [[value toString] addExecutionStringToScript];
         return @{
             kBSMediaStrategyAcceptMethod: method,
             kBSMediaStrategyKeyAccept: (acceptScript ?: @"")

--- a/BeardedSpice/MediaStrategies/PlexWeb.js
+++ b/BeardedSpice/MediaStrategies/PlexWeb.js
@@ -6,11 +6,13 @@
 //  Copyright (c) 2015 BeardedSpice. All rights reserved.
 //
 BSStrategy = {
-  version:1,
+  version:2,
   displayName:"Plex Web",
   accepts: {
     method: "script",
-    script: function accepts () {return (window.PLEXWEB != undefined);}
+    script: function accepts () {
+        return (window.PLEXWEB != undefined || document.querySelector('#plex') != null);
+    },
   },
   isPlaying: function()  {
     var theButton = document.querySelector('.player.music .pause-btn');

--- a/BeardedSpice/MediaStrategies/versions.plist
+++ b/BeardedSpice/MediaStrategies/versions.plist
@@ -87,7 +87,7 @@
 	<key>Pandora</key>
 	<integer>1</integer>
 	<key>PlexWeb</key>
-	<integer>1</integer>
+	<integer>2</integer>
 	<key>PocketCasts</key>
 	<integer>1</integer>
 	<key>PoolsideFM</key>


### PR DESCRIPTION
1. Still trying to fix Plex's new UI, but the fix is now backwards compatible, see https://github.com/beardedspice/beardedspice/pull/379

2. While trying to fix this, I got stuck for a few hours with the new JS format for "accepts". Plex is the only strategy using this, so I don't think it has surfaced. It seems like the Google Chrome 46 hack was executing the plex web "accepts" strategy function too early. That is why I want to add the addExecutionStringToScript method call.

In debugging, the difference is like so: 

```
2016-07-16 13:34:25.410 BeardedSpice[77308:4000369] heyyyyyyyyyy
2016-07-16 13:34:25.411 BeardedSpice[77308:4000369] (function accepts() {
        return (window.PLEXWEB != undefined || document.querySelector('#plex') != null);
    })();

2016-07-16 13:34:25.411 BeardedSpice[77308:4000369] ((function accepts() {
        return (window.PLEXWEB != undefined || document.querySelector('#plex') != null);
    })();)();
```

This is getting used by this is hackResult stuff, but was getting evaluated when it was written in the DOM.
```
NSString *javascriptString =[NSString stringWithFormat:@"javascript:(function(){id='" HACK_NAME @"';if (document.getElementById(id) === null){node = document.createElement('pre');node.id = id;node.hidden = true; document.getElementsByTagName('body')[0].appendChild(node);} document.getElementById(id).innerText =  (function(){ var hackResult = %@; return JSON.stringify({'hackResult': hackResult}); })();})();", [javascript stringForSubstitutionInJavascriptPlaceholder]];
```

So uh let me know if you need more explanation or are there tests I should write? I'm pretty out of my depth here in the objc world...