### PR TITLE
Fix plex toggle strategy

### DIFF
--- a/BeardedSpice/MediaStrategies/PlexWeb.js
+++ b/BeardedSpice/MediaStrategies/PlexWeb.js
@@ -26,7 +26,7 @@ BSStrategy = {
     var thePlayer = document.querySelector('.player.music') ? '.player.music' : '.video-player';
     var pauseButton = document.querySelector(thePlayer + ' .pause-btn');
     var buttonIsHidden = pauseButton.classList.contains('hidden');
-    var toggleButton = document.querySelector((buttonIsHidden ? ' .play' : ' .pause') + '-btn');
+    var toggleButton = document.querySelector('button' + (buttonIsHidden ? '.play' : '.pause') + '-btn');
     toggleButton.click();
   },
   next: function () {

--- a/BeardedSpice/MediaStrategies/PlexWeb.js
+++ b/BeardedSpice/MediaStrategies/PlexWeb.js
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 BeardedSpice. All rights reserved.
 //
 BSStrategy = {
-  version:2,
+  version:3,
   displayName:"Plex Web",
   accepts: {
     method: "script",

--- a/BeardedSpice/MediaStrategies/PlexWeb.js
+++ b/BeardedSpice/MediaStrategies/PlexWeb.js
@@ -14,20 +14,19 @@ BSStrategy = {
         return (window.PLEXWEB != undefined || document.querySelector('#plex') != null);
     },
   },
-  isPlaying: function()  {
+  isPlaying: function() {
     var theButton = document.querySelector('.player.music .pause-btn');
     if (theButton)
       return !(theButton.classList.contains('hidden'));
     else
       return (document.querySelector('.video-player.playing') != undefined);
   },
-  toggle: function ()  {
+  // Use the visibility of the pause button to determine if something is playing
+  toggle: function () {
     var thePlayer = document.querySelector('.player.music') ? '.player.music' : '.video-player';
-    var pauseButton = document.querySelector(thePlayer+' .pause-btn');
-    var playerButton = document.querySelector(thePlayer+pauseButton)
-    var classList = playerButton.classList;
-    var listHasHidden = classList.contains('hidden');
-    var toggleButton = document.querySelector((listHasHidden ? ' .play' : ' .pause') + '-btn');
+    var pauseButton = document.querySelector(thePlayer + ' .pause-btn');
+    var buttonIsHidden = pauseButton.classList.contains('hidden');
+    var toggleButton = document.querySelector((buttonIsHidden ? ' .play' : ' .pause') + '-btn');
     toggleButton.click();
   },
   next: function () {
@@ -40,7 +39,7 @@ BSStrategy = {
   },
   pause: function () {
     var thePlayer = document.querySelector('.player.music') ? '.player.music' : '.video-player';
-    document.querySelector(thePlayer+' .pause-btn').click()
+    document.querySelector(thePlayer + ' .pause-btn').click()
   },
   trackInfo: function () {
     if (document.querySelector('.player.music')) {

--- a/BeardedSpice/MediaStrategies/versions.plist
+++ b/BeardedSpice/MediaStrategies/versions.plist
@@ -87,7 +87,7 @@
 	<key>Pandora</key>
 	<integer>1</integer>
 	<key>PlexWeb</key>
-	<integer>2</integer>
+	<integer>3</integer>
 	<key>PocketCasts</key>
 	<integer>1</integer>
 	<key>PoolsideFM</key>


### PR DESCRIPTION
I jumped the gun a bit on https://github.com/beardedspice/beardedspice/pull/449

This PR fixes the toggle functionality, which has been broken I think in master?

I'm on Plex Web 2.7.0 (latest) and I tested all major functionality
- Music/video play/pause work
- next/previous with music work
- all music/video info appears correctly in the menubar info