### PR TITLE
Adds support for Downcast (Mac OS)

### DIFF
--- a/BeardedSpice.xcodeproj/project.pbxproj
+++ b/BeardedSpice.xcodeproj/project.pbxproj
@@ -8,34 +8,159 @@
 
 /* Begin PBXBuildFile section */
 		0301233A1868B1F90080115F /* BeardedSpiceUserDefaults.plist in Resources */ = {isa = PBXBuildFile; fileRef = 030123391868B1F90080115F /* BeardedSpiceUserDefaults.plist */; };
+		0320C0521868C6C2009591CA /* beard.png in Resources */ = {isa = PBXBuildFile; fileRef = 0320C0511868C6C2009591CA /* beard.png */; };
+		0320C0541868C7A4009591CA /* beard-highlighted.png in Resources */ = {isa = PBXBuildFile; fileRef = 0320C0531868C7A4009591CA /* beard-highlighted.png */; };
 		0369231F1862936600E04DDB /* GeneralPreferencesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0369231D1862936600E04DDB /* GeneralPreferencesViewController.m */; };
 		03A34922185EA43900C4A62B /* MediaStrategyRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 03A34921185EA43900C4A62B /* MediaStrategyRegistry.m */; };
 		03F33EED1857E3C000E8F77E /* ChromeTabAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 03F33EEC1857E3C000E8F77E /* ChromeTabAdapter.m */; };
 		03F33EF01857E59B00E8F77E /* SafariTabAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 03F33EEF1857E59B00E8F77E /* SafariTabAdapter.m */; };
-		0B1AF37E1CCE4D4C0021BBEA /* BSMediaStrategyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B1AF3761CCE4D4C0021BBEA /* BSMediaStrategyTests.m */; };
-		0B1AF37F1CCE4D4C0021BBEA /* BSStrategyMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B1AF3781CCE4D4C0021BBEA /* BSStrategyMockObject.m */; };
-		0B1AF3801CCE4D4C0021BBEA /* BSStrategyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B1AF3791CCE4D4C0021BBEA /* BSStrategyTests.m */; };
-		0B1AF3831CCE4D4C0021BBEA /* BSTrackTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B1AF37C1CCE4D4C0021BBEA /* BSTrackTests.m */; };
-		0B33014E1CFA643F0090DB67 /* BSStrategyCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B33014D1CFA643F0090DB67 /* BSStrategyCache.m */; };
-		0B33014F1CFA643F0090DB67 /* BSStrategyCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B33014D1CFA643F0090DB67 /* BSStrategyCache.m */; };
 		0B355EF71CBEA3350089C2B3 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 0B355EF51CBEA3350089C2B3 /* Localizable.strings */; };
-		0BD1B2F31CD21AA900B72A3E /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0BD1B2F21CD21AA900B72A3E /* JavaScriptCore.framework */; };
-		0BD1B2F41CD21AB100B72A3E /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0BD1B2F21CD21AA900B72A3E /* JavaScriptCore.framework */; };
-		0BE800771CDA4F5B001A4DDF /* versions.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BE8FFFA1CDA4F5B001A4DDF /* versions.plist */; };
-		0BE800781CDA4F5B001A4DDF /* versions.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BE8FFFA1CDA4F5B001A4DDF /* versions.plist */; };
+		0BF06A551C95139A00534083 /* AmazonMusic.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A121C95139900534083 /* AmazonMusic.plist */; };
+		0BF06A561C95139A00534083 /* AmazonMusic.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A121C95139900534083 /* AmazonMusic.plist */; };
+		0BF06A571C95139A00534083 /* Audible.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A131C95139900534083 /* Audible.plist */; };
+		0BF06A581C95139A00534083 /* Audible.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A131C95139900534083 /* Audible.plist */; };
+		0BF06A591C95139A00534083 /* AudioMack.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A141C95139900534083 /* AudioMack.plist */; };
+		0BF06A5A1C95139A00534083 /* AudioMack.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A141C95139900534083 /* AudioMack.plist */; };
+		0BF06A5B1C95139A00534083 /* BandCamp.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A151C95139900534083 /* BandCamp.plist */; };
+		0BF06A5C1C95139A00534083 /* BandCamp.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A151C95139900534083 /* BandCamp.plist */; };
+		0BF06A5D1C95139A00534083 /* BBCRadio.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A161C95139900534083 /* BBCRadio.plist */; };
+		0BF06A5E1C95139A00534083 /* BBCRadio.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A161C95139900534083 /* BBCRadio.plist */; };
+		0BF06A5F1C95139A00534083 /* Beatguide.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A171C95139900534083 /* Beatguide.plist */; };
+		0BF06A601C95139A00534083 /* Beatguide.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A171C95139900534083 /* Beatguide.plist */; };
+		0BF06A611C95139A00534083 /* BeatsMusic.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A181C95139900534083 /* BeatsMusic.plist */; };
+		0BF06A621C95139A00534083 /* BeatsMusic.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A181C95139900534083 /* BeatsMusic.plist */; };
+		0BF06A631C95139A00534083 /* Blitzr.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A191C95139900534083 /* Blitzr.plist */; };
+		0BF06A641C95139A00534083 /* Blitzr.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A191C95139900534083 /* Blitzr.plist */; };
+		0BF06A651C95139A00534083 /* BrainFm.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A1A1C95139900534083 /* BrainFm.plist */; };
+		0BF06A661C95139A00534083 /* BrainFm.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A1A1C95139900534083 /* BrainFm.plist */; };
+		0BF06A671C95139A00534083 /* BugsMusic.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A1B1C95139900534083 /* BugsMusic.plist */; };
+		0BF06A681C95139A00534083 /* BugsMusic.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A1B1C95139900534083 /* BugsMusic.plist */; };
+		0BF06A691C95139A00534083 /* Chorus.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A1C1C95139900534083 /* Chorus.plist */; };
+		0BF06A6A1C95139A00534083 /* Chorus.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A1C1C95139900534083 /* Chorus.plist */; };
+		0BF06A6B1C95139A00534083 /* Composed.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A1D1C95139900534083 /* Composed.plist */; };
+		0BF06A6C1C95139A00534083 /* Composed.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A1D1C95139900534083 /* Composed.plist */; };
+		0BF06A6D1C95139A00534083 /* Coursera.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A1E1C95139900534083 /* Coursera.plist */; };
+		0BF06A6E1C95139A00534083 /* Coursera.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A1E1C95139900534083 /* Coursera.plist */; };
+		0BF06A6F1C95139A00534083 /* Deezer.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A1F1C95139900534083 /* Deezer.plist */; };
+		0BF06A701C95139A00534083 /* Deezer.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A1F1C95139900534083 /* Deezer.plist */; };
+		0BF06A711C95139A00534083 /* DigitallyImported.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A201C95139900534083 /* DigitallyImported.plist */; };
+		0BF06A721C95139A00534083 /* DigitallyImported.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A201C95139900534083 /* DigitallyImported.plist */; };
+		0BF06A731C95139A00534083 /* EightTracks.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A211C95139900534083 /* EightTracks.plist */; };
+		0BF06A741C95139A00534083 /* EightTracks.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A211C95139900534083 /* EightTracks.plist */; };
+		0BF06A751C95139A00534083 /* FocusAtWill.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A221C95139900534083 /* FocusAtWill.plist */; };
+		0BF06A761C95139A00534083 /* FocusAtWill.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A221C95139900534083 /* FocusAtWill.plist */; };
+		0BF06A771C95139A00534083 /* GoogleMusic.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A231C95139900534083 /* GoogleMusic.plist */; };
+		0BF06A781C95139A00534083 /* GoogleMusic.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A231C95139900534083 /* GoogleMusic.plist */; };
+		0BF06A791C95139A00534083 /* GrooveShark.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A241C95139900534083 /* GrooveShark.plist */; };
+		0BF06A7A1C95139A00534083 /* GrooveShark.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A241C95139900534083 /* GrooveShark.plist */; };
+		0BF06A7B1C95139A00534083 /* HotNewHipHop.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A251C95139900534083 /* HotNewHipHop.plist */; };
+		0BF06A7C1C95139A00534083 /* HotNewHipHop.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A251C95139900534083 /* HotNewHipHop.plist */; };
+		0BF06A7D1C95139A00534083 /* HypeMachine.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A261C95139900534083 /* HypeMachine.plist */; };
+		0BF06A7E1C95139A00534083 /* HypeMachine.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A261C95139900534083 /* HypeMachine.plist */; };
+		0BF06A7F1C95139A00534083 /* iHeartRadio.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A271C95139A00534083 /* iHeartRadio.plist */; };
+		0BF06A801C95139A00534083 /* iHeartRadio.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A271C95139A00534083 /* iHeartRadio.plist */; };
+		0BF06A811C95139A00534083 /* IndieShuffle.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A281C95139A00534083 /* IndieShuffle.plist */; };
+		0BF06A821C95139A00534083 /* IndieShuffle.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A281C95139A00534083 /* IndieShuffle.plist */; };
+		0BF06A831C95139A00534083 /* Jango.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A291C95139A00534083 /* Jango.plist */; };
+		0BF06A841C95139A00534083 /* Jango.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A291C95139A00534083 /* Jango.plist */; };
+		0BF06A851C95139A00534083 /* KollektFm.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A2A1C95139A00534083 /* KollektFm.plist */; };
+		0BF06A861C95139A00534083 /* KollektFm.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A2A1C95139A00534083 /* KollektFm.plist */; };
+		0BF06A871C95139A00534083 /* LastFm.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A2B1C95139A00534083 /* LastFm.plist */; };
+		0BF06A881C95139A00534083 /* LastFm.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A2B1C95139A00534083 /* LastFm.plist */; };
+		0BF06A891C95139A00534083 /* LeTournedisque.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A2C1C95139A00534083 /* LeTournedisque.plist */; };
+		0BF06A8A1C95139A00534083 /* LeTournedisque.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A2C1C95139A00534083 /* LeTournedisque.plist */; };
+		0BF06A8B1C95139A00534083 /* LogitechMediaServer.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A2D1C95139A00534083 /* LogitechMediaServer.plist */; };
+		0BF06A8C1C95139A00534083 /* LogitechMediaServer.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A2D1C95139A00534083 /* LogitechMediaServer.plist */; };
+		0BF06A8D1C95139A00534083 /* MixCloud.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A2E1C95139A00534083 /* MixCloud.plist */; };
+		0BF06A8E1C95139A00534083 /* MixCloud.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A2E1C95139A00534083 /* MixCloud.plist */; };
+		0BF06A8F1C95139A00534083 /* MusicForProgramming.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A2F1C95139A00534083 /* MusicForProgramming.plist */; };
+		0BF06A901C95139A00534083 /* MusicForProgramming.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A2F1C95139A00534083 /* MusicForProgramming.plist */; };
+		0BF06A911C95139A00534083 /* MusicUnlimited.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A301C95139A00534083 /* MusicUnlimited.plist */; };
+		0BF06A921C95139A00534083 /* MusicUnlimited.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A301C95139A00534083 /* MusicUnlimited.plist */; };
+		0BF06A931C95139A00534083 /* Netflix.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A311C95139A00534083 /* Netflix.plist */; };
+		0BF06A941C95139A00534083 /* Netflix.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A311C95139A00534083 /* Netflix.plist */; };
+		0BF06A951C95139A00534083 /* NoAdRadio.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A321C95139A00534083 /* NoAdRadio.plist */; };
+		0BF06A961C95139A00534083 /* NoAdRadio.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A321C95139A00534083 /* NoAdRadio.plist */; };
+		0BF06A971C95139A00534083 /* NoonPacific.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A331C95139A00534083 /* NoonPacific.plist */; };
+		0BF06A981C95139A00534083 /* NoonPacific.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A331C95139A00534083 /* NoonPacific.plist */; };
+		0BF06A991C95139A00534083 /* NRK.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A341C95139A00534083 /* NRK.plist */; };
+		0BF06A9A1C95139A00534083 /* NRK.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A341C95139A00534083 /* NRK.plist */; };
+		0BF06A9B1C95139A00534083 /* Odnoklassniki.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A351C95139A00534083 /* Odnoklassniki.plist */; };
+		0BF06A9C1C95139A00534083 /* Odnoklassniki.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A351C95139A00534083 /* Odnoklassniki.plist */; };
+		0BF06A9D1C95139A00534083 /* Overcast.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A361C95139A00534083 /* Overcast.plist */; };
+		0BF06A9E1C95139A00534083 /* Overcast.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A361C95139A00534083 /* Overcast.plist */; };
+		0BF06A9F1C95139A00534083 /* Pandora.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A371C95139A00534083 /* Pandora.plist */; };
+		0BF06AA01C95139A00534083 /* Pandora.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A371C95139A00534083 /* Pandora.plist */; };
+		0BF06AA11C95139A00534083 /* PlexWeb.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A381C95139A00534083 /* PlexWeb.plist */; };
+		0BF06AA21C95139A00534083 /* PlexWeb.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A381C95139A00534083 /* PlexWeb.plist */; };
+		0BF06AA31C95139A00534083 /* PocketCasts.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A391C95139A00534083 /* PocketCasts.plist */; };
+		0BF06AA41C95139A00534083 /* PocketCasts.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A391C95139A00534083 /* PocketCasts.plist */; };
+		0BF06AA51C95139A00534083 /* Rdio.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A3A1C95139A00534083 /* Rdio.plist */; };
+		0BF06AA61C95139A00534083 /* Rdio.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A3A1C95139A00534083 /* Rdio.plist */; };
+		0BF06AA71C95139A00534083 /* Rhapsody.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A3B1C95139A00534083 /* Rhapsody.plist */; };
+		0BF06AA81C95139A00534083 /* Rhapsody.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A3B1C95139A00534083 /* Rhapsody.plist */; };
+		0BF06AA91C95139A00534083 /* Saavn.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A3C1C95139A00534083 /* Saavn.plist */; };
+		0BF06AAA1C95139A00534083 /* Saavn.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A3C1C95139A00534083 /* Saavn.plist */; };
+		0BF06AAB1C95139A00534083 /* ShufflerFm.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A3D1C95139A00534083 /* ShufflerFm.plist */; };
+		0BF06AAC1C95139A00534083 /* ShufflerFm.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A3D1C95139A00534083 /* ShufflerFm.plist */; };
+		0BF06AAD1C95139A00534083 /* Slacker.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A3E1C95139A00534083 /* Slacker.plist */; };
+		0BF06AAE1C95139A00534083 /* Slacker.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A3E1C95139A00534083 /* Slacker.plist */; };
+		0BF06AAF1C95139A00534083 /* SomaFm.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A3F1C95139A00534083 /* SomaFm.plist */; };
+		0BF06AB01C95139A00534083 /* SomaFm.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A3F1C95139A00534083 /* SomaFm.plist */; };
+		0BF06AB11C95139A00534083 /* Songza.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A401C95139A00534083 /* Songza.plist */; };
+		0BF06AB21C95139A00534083 /* Songza.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A401C95139A00534083 /* Songza.plist */; };
+		0BF06AB31C95139A00534083 /* SoundCloud.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A411C95139A00534083 /* SoundCloud.plist */; };
+		0BF06AB41C95139A00534083 /* SoundCloud.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A411C95139A00534083 /* SoundCloud.plist */; };
+		0BF06AB51C95139A00534083 /* Spotify.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A421C95139A00534083 /* Spotify.plist */; };
+		0BF06AB61C95139A00534083 /* Spotify.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A421C95139A00534083 /* Spotify.plist */; };
+		0BF06AB71C95139A00534083 /* Stitcher.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A431C95139A00534083 /* Stitcher.plist */; };
+		0BF06AB81C95139A00534083 /* Stitcher.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A431C95139A00534083 /* Stitcher.plist */; };
+		0BF06AB91C95139A00534083 /* Subsonic.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A441C95139A00534083 /* Subsonic.plist */; };
+		0BF06ABA1C95139A00534083 /* Subsonic.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A441C95139A00534083 /* Subsonic.plist */; };
+		0BF06ABB1C95139A00534083 /* Synology.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A451C95139A00534083 /* Synology.plist */; };
+		0BF06ABC1C95139A00534083 /* Synology.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A451C95139A00534083 /* Synology.plist */; };
+		0BF06ABD1C95139A00534083 /* TidalHiFi.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A461C95139A00534083 /* TidalHiFi.plist */; };
+		0BF06ABE1C95139A00534083 /* TidalHiFi.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A461C95139A00534083 /* TidalHiFi.plist */; };
+		0BF06ABF1C95139A00534083 /* TuneIn.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A471C95139A00534083 /* TuneIn.plist */; };
+		0BF06AC01C95139A00534083 /* TuneIn.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A471C95139A00534083 /* TuneIn.plist */; };
+		0BF06AC11C95139A00534083 /* TwentyTwoTracks.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A481C95139A00534083 /* TwentyTwoTracks.plist */; };
+		0BF06AC21C95139A00534083 /* TwentyTwoTracks.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A481C95139A00534083 /* TwentyTwoTracks.plist */; };
+		0BF06AC31C95139A00534083 /* Twitch.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A491C95139A00534083 /* Twitch.plist */; };
+		0BF06AC41C95139A00534083 /* Twitch.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A491C95139A00534083 /* Twitch.plist */; };
+		0BF06AC51C95139A00534083 /* Udemy.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A4A1C95139A00534083 /* Udemy.plist */; };
+		0BF06AC61C95139A00534083 /* Udemy.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A4A1C95139A00534083 /* Udemy.plist */; };
+		0BF06AC71C95139A00534083 /* versions.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A4B1C95139A00534083 /* versions.plist */; };
+		0BF06AC81C95139A00534083 /* versions.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A4B1C95139A00534083 /* versions.plist */; };
+		0BF06AC91C95139A00534083 /* Vessel.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A4C1C95139A00534083 /* Vessel.plist */; };
+		0BF06ACA1C95139A00534083 /* Vessel.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A4C1C95139A00534083 /* Vessel.plist */; };
+		0BF06ACB1C95139A00534083 /* Vimeo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A4D1C95139A00534083 /* Vimeo.plist */; };
+		0BF06ACC1C95139A00534083 /* Vimeo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A4D1C95139A00534083 /* Vimeo.plist */; };
+		0BF06ACD1C95139A00534083 /* Vk.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A4E1C95139A00534083 /* Vk.plist */; };
+		0BF06ACE1C95139A00534083 /* Vk.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A4E1C95139A00534083 /* Vk.plist */; };
+		0BF06ACF1C95139A00534083 /* WatchaPlay.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A4F1C95139A00534083 /* WatchaPlay.plist */; };
+		0BF06AD01C95139A00534083 /* WatchaPlay.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A4F1C95139A00534083 /* WatchaPlay.plist */; };
+		0BF06AD11C95139A00534083 /* WonderFm.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A501C95139A00534083 /* WonderFm.plist */; };
+		0BF06AD21C95139A00534083 /* WonderFm.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A501C95139A00534083 /* WonderFm.plist */; };
+		0BF06AD31C95139A00534083 /* XboxMusic.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A511C95139A00534083 /* XboxMusic.plist */; };
+		0BF06AD41C95139A00534083 /* XboxMusic.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A511C95139A00534083 /* XboxMusic.plist */; };
+		0BF06AD51C95139A00534083 /* YandexMusic.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A521C95139A00534083 /* YandexMusic.plist */; };
+		0BF06AD61C95139A00534083 /* YandexMusic.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A521C95139A00534083 /* YandexMusic.plist */; };
+		0BF06AD71C95139A00534083 /* YandexRadio.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A531C95139A00534083 /* YandexRadio.plist */; };
+		0BF06AD81C95139A00534083 /* YandexRadio.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A531C95139A00534083 /* YandexRadio.plist */; };
+		0BF06AD91C95139A00534083 /* Youtube.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A541C95139A00534083 /* Youtube.plist */; };
+		0BF06ADA1C95139A00534083 /* Youtube.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A541C95139A00534083 /* Youtube.plist */; };
 		0BF06AE11C9513A800534083 /* BSMediaStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BF06ADC1C9513A800534083 /* BSMediaStrategy.m */; };
 		0BF06AE31C9513A800534083 /* BSStrategyVersionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BF06ADE1C9513A800534083 /* BSStrategyVersionManager.m */; };
 		0BF06AE51C9513A800534083 /* BSTrack.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BF06AE01C9513A800534083 /* BSTrack.m */; };
-		0BF9CAE71CFFDB2F00E9986B /* NSString+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 656A002C1C8AD41A00BD29F5 /* NSString+Utils.m */; };
-		11A36C1600CD983E3627C87A /* libPods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 53666B3CA02A56F052042196 /* libPods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.a */; };
-		57EC5B34F4AD4F87F5D44625 /* libPods-BeardedSpiceControllers.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7FAD2F3C92017C9093D70503 /* libPods-BeardedSpiceControllers.a */; };
+		17C5B63A18DB33C0006F38C1 /* beard@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 17C5B63918DB33C0006F38C1 /* beard@2x.png */; };
+		17C5B63C18DB3649006F38C1 /* beard-highlighted@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 17C5B63B18DB3649006F38C1 /* beard-highlighted@2x.png */; };
+		1E1426F8950EBED0E2020816 /* libPods-BeardedSpiceControllers.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F20B81547A29635C2DF0434 /* libPods-BeardedSpiceControllers.a */; };
+		5ECFDCD81CD8F8DE00811169 /* DowncastTabAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ECFDCD71CD8F8DE00811169 /* DowncastTabAdapter.m */; };
 		651967C21AB3A0B200B48D3A /* iTunesTabAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 651967C11AB3A0B200B48D3A /* iTunesTabAdapter.m */; };
 		6537DAA81AF396DA002F2391 /* NativeAppTabRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 6537DAA71AF396DA002F2391 /* NativeAppTabRegistry.m */; };
 		6537DAAB1AF508DF002F2391 /* MediaControllerObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 6537DAAA1AF508DF002F2391 /* MediaControllerObject.m */; };
 		6537DAAD1AF6E666002F2391 /* SpotifyTabAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 65C511691AED66A700EBA6A5 /* SpotifyTabAdapter.m */; };
 		653BCAD21AB25DAC0034D27F /* ShortcutsPreferencesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 653BCAD01AB25DAC0034D27F /* ShortcutsPreferencesViewController.m */; };
-		655AACA91D3ABFAA00E316EA /* EHCCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 655AACA61D3ABFAA00E316EA /* EHCCache.m */; };
-		655AACAA1D3ABFAA00E316EA /* NSArray+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 655AACA81D3ABFAA00E316EA /* NSArray+Utils.m */; };
 		656A00131C8AD3C800BD29F5 /* DDHidAppleMikey.m in Sources */ = {isa = PBXBuildFile; fileRef = 656A00001C8AD3C800BD29F5 /* DDHidAppleMikey.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		656A00141C8AD3C800BD29F5 /* DDHidAppleRemote.m in Sources */ = {isa = PBXBuildFile; fileRef = 656A00021C8AD3C800BD29F5 /* DDHidAppleRemote.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		656A00151C8AD3C800BD29F5 /* DDHidDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = 656A00041C8AD3C800BD29F5 /* DDHidDevice.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
@@ -55,6 +180,7 @@
 		656A00331C8AD41A00BD29F5 /* NSException+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 656A002A1C8AD41A00BD29F5 /* NSException+Utils.m */; };
 		656A00341C8AD41A00BD29F5 /* NSException+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 656A002A1C8AD41A00BD29F5 /* NSException+Utils.m */; };
 		656A00351C8AD41A00BD29F5 /* NSString+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 656A002C1C8AD41A00BD29F5 /* NSString+Utils.m */; };
+		656A00361C8AD41A00BD29F5 /* NSString+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 656A002C1C8AD41A00BD29F5 /* NSString+Utils.m */; };
 		656A00371C8AD41A00BD29F5 /* NSURL+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 656A002E1C8AD41A00BD29F5 /* NSURL+Utils.m */; };
 		656A00381C8AD41A00BD29F5 /* NSURL+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 656A002E1C8AD41A00BD29F5 /* NSURL+Utils.m */; };
 		656A003D1C8B01BC00BD29F5 /* BSSharedDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = 656A003C1C8B01BC00BD29F5 /* BSSharedDefaults.m */; };
@@ -69,21 +195,14 @@
 		65A850191C8DE9D900D54C77 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03F33ECB1855306A00E8F77E /* Carbon.framework */; };
 		65A8501A1C8DE9E000D54C77 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65E567071B76104300AD2D46 /* CoreAudio.framework */; };
 		65A8501D1C9330F800D54C77 /* BSCShortcutMonitor.m in Sources */ = {isa = PBXBuildFile; fileRef = 65A8501C1C9330F800D54C77 /* BSCShortcutMonitor.m */; };
-		65ABBAA61D1EC7D000F882CE /* BSCustomStrategyManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 65ABBAA51D1EC7D000F882CE /* BSCustomStrategyManager.m */; };
-		65ADE6051D169D0C000C29F1 /* EHVerticalCenteredTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = 65ADE6041D169D0C000C29F1 /* EHVerticalCenteredTextField.m */; };
 		65B32B8E1AD99D1600F696B9 /* TabAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B32B8D1AD99D1600F696B9 /* TabAdapter.m */; };
 		65C511721AED802B00EBA6A5 /* NativeAppTabAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 65C511711AED802B00EBA6A5 /* NativeAppTabAdapter.m */; };
-		65D57FCB1D02CBFE0016F270 /* MediaStrategies in Resources */ = {isa = PBXBuildFile; fileRef = 65D57FCA1D02CBFE0016F270 /* MediaStrategies */; };
-		65D57FCC1D02CC250016F270 /* MediaStrategies in Resources */ = {isa = PBXBuildFile; fileRef = 65D57FCA1D02CBFE0016F270 /* MediaStrategies */; };
-		65D57FCD1D02CCB00016F270 /* NSURL+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 656A002E1C8AD41A00BD29F5 /* NSURL+Utils.m */; };
-		65D57FCE1D02CD140016F270 /* BSMediaStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BF06ADC1C9513A800534083 /* BSMediaStrategy.m */; };
 		65E5670E1B76A07700AD2D46 /* BSMediaStrategyEnableButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 65E5670D1B76A07700AD2D46 /* BSMediaStrategyEnableButton.m */; };
 		65E567111B76AE3A00AD2D46 /* BSPreferencesWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 65E567101B76AE3A00AD2D46 /* BSPreferencesWindowController.m */; };
 		65E567141B775C9300AD2D46 /* BSShortcutView.m in Sources */ = {isa = PBXBuildFile; fileRef = 65E567131B775C9300AD2D46 /* BSShortcutView.m */; };
 		65EE289E1AB6003800EFC886 /* GeneralPreferencesView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 65EE28A01AB6003800EFC886 /* GeneralPreferencesView.xib */; };
 		65EE28A11AB6003B00EFC886 /* ShortcutsPreferencesView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 65EE28A31AB6003B00EFC886 /* ShortcutsPreferencesView.xib */; };
 		65FF756C1B36CEDF00D81CA5 /* BSLaunchAtLogin.m in Sources */ = {isa = PBXBuildFile; fileRef = 65FF756B1B36CEDF00D81CA5 /* BSLaunchAtLogin.m */; };
-		7D8A002D0E49A89BB9CB53DD /* libPods-BeardedSpiceControllers-BeardedSpice.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A13F7ACE82D7C5DF91641532 /* libPods-BeardedSpiceControllers-BeardedSpice.a */; };
 		967933301855173100A49AC7 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9679332F1855173100A49AC7 /* Cocoa.framework */; };
 		9679333C1855173100A49AC7 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 9679333B1855173100A49AC7 /* main.m */; };
 		967933431855173100A49AC7 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 967933421855173100A49AC7 /* AppDelegate.m */; };
@@ -91,8 +210,11 @@
 		967933481855173100A49AC7 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 967933471855173100A49AC7 /* Images.xcassets */; };
 		9679334F1855173100A49AC7 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9679334E1855173100A49AC7 /* XCTest.framework */; };
 		967933501855173100A49AC7 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9679332F1855173100A49AC7 /* Cocoa.framework */; };
+		9679335A1855173100A49AC7 /* BeardedSpiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 967933591855173100A49AC7 /* BeardedSpiceTests.m */; };
 		9679336518551BCC00A49AC7 /* ScriptingBridge.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9679336418551BCC00A49AC7 /* ScriptingBridge.framework */; };
+		C7EBE1D19BB5376934A3F6D3 /* libPods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 45EC506CE39EEDB80F99EA07 /* libPods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.a */; };
 		D09EFF221C8CD49E00B24DA9 /* VLCTabAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = D09EFF1F1C8CD49E00B24DA9 /* VLCTabAdapter.m */; };
+		DAD858605B37FF09D3AAD082 /* libPods-BeardedSpiceControllers-BeardedSpice.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 28CA978C46A156EA9D1CFA4A /* libPods-BeardedSpiceControllers-BeardedSpice.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -138,8 +260,10 @@
 
 /* Begin PBXFileReference section */
 		030123391868B1F90080115F /* BeardedSpiceUserDefaults.plist */ = {isa = PBXFileReference; lastKnownFileType = file.bplist; path = BeardedSpiceUserDefaults.plist; sourceTree = "<group>"; };
+		0320C0511868C6C2009591CA /* beard.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = beard.png; sourceTree = "<group>"; };
+		0320C0531868C7A4009591CA /* beard-highlighted.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "beard-highlighted.png"; sourceTree = "<group>"; };
 		0369231C1862936600E04DDB /* GeneralPreferencesViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GeneralPreferencesViewController.h; sourceTree = "<group>"; };
-		0369231D1862936600E04DDB /* GeneralPreferencesViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = GeneralPreferencesViewController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		0369231D1862936600E04DDB /* GeneralPreferencesViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneralPreferencesViewController.m; sourceTree = "<group>"; };
 		03A34920185EA43900C4A62B /* MediaStrategyRegistry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = MediaStrategyRegistry.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		03A34921185EA43900C4A62B /* MediaStrategyRegistry.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = MediaStrategyRegistry.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		03F33ECB1855306A00E8F77E /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
@@ -148,44 +272,101 @@
 		03F33EEC1857E3C000E8F77E /* ChromeTabAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = ChromeTabAdapter.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		03F33EEE1857E59B00E8F77E /* SafariTabAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = SafariTabAdapter.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		03F33EEF1857E59B00E8F77E /* SafariTabAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = SafariTabAdapter.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		0B1AF3761CCE4D4C0021BBEA /* BSMediaStrategyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSMediaStrategyTests.m; sourceTree = "<group>"; };
-		0B1AF3771CCE4D4C0021BBEA /* BSStrategyMockObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSStrategyMockObject.h; sourceTree = "<group>"; };
-		0B1AF3781CCE4D4C0021BBEA /* BSStrategyMockObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSStrategyMockObject.m; sourceTree = "<group>"; };
-		0B1AF3791CCE4D4C0021BBEA /* BSStrategyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSStrategyTests.m; sourceTree = "<group>"; };
-		0B1AF37C1CCE4D4C0021BBEA /* BSTrackTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSTrackTests.m; sourceTree = "<group>"; };
-		0B33014C1CFA643F0090DB67 /* BSStrategyCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSStrategyCache.h; sourceTree = "<group>"; };
-		0B33014D1CFA643F0090DB67 /* BSStrategyCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSStrategyCache.m; sourceTree = "<group>"; };
-		0BD1B2F21CD21AA900B72A3E /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
-		0BE8FFFA1CDA4F5B001A4DDF /* versions.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = versions.plist; path = MediaStrategies/versions.plist; sourceTree = "<group>"; };
+		0BF06A121C95139900534083 /* AmazonMusic.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = AmazonMusic.plist; sourceTree = "<group>"; };
+		0BF06A131C95139900534083 /* Audible.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Audible.plist; sourceTree = "<group>"; };
+		0BF06A141C95139900534083 /* AudioMack.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = AudioMack.plist; sourceTree = "<group>"; };
+		0BF06A151C95139900534083 /* BandCamp.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = BandCamp.plist; sourceTree = "<group>"; };
+		0BF06A161C95139900534083 /* BBCRadio.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = BBCRadio.plist; sourceTree = "<group>"; };
+		0BF06A171C95139900534083 /* Beatguide.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Beatguide.plist; sourceTree = "<group>"; };
+		0BF06A181C95139900534083 /* BeatsMusic.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = BeatsMusic.plist; sourceTree = "<group>"; };
+		0BF06A191C95139900534083 /* Blitzr.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Blitzr.plist; sourceTree = "<group>"; };
+		0BF06A1A1C95139900534083 /* BrainFm.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = BrainFm.plist; sourceTree = "<group>"; };
+		0BF06A1B1C95139900534083 /* BugsMusic.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = BugsMusic.plist; sourceTree = "<group>"; };
+		0BF06A1C1C95139900534083 /* Chorus.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Chorus.plist; sourceTree = "<group>"; };
+		0BF06A1D1C95139900534083 /* Composed.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Composed.plist; sourceTree = "<group>"; };
+		0BF06A1E1C95139900534083 /* Coursera.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Coursera.plist; sourceTree = "<group>"; };
+		0BF06A1F1C95139900534083 /* Deezer.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Deezer.plist; sourceTree = "<group>"; };
+		0BF06A201C95139900534083 /* DigitallyImported.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = DigitallyImported.plist; sourceTree = "<group>"; };
+		0BF06A211C95139900534083 /* EightTracks.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = EightTracks.plist; sourceTree = "<group>"; };
+		0BF06A221C95139900534083 /* FocusAtWill.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = FocusAtWill.plist; sourceTree = "<group>"; };
+		0BF06A231C95139900534083 /* GoogleMusic.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = GoogleMusic.plist; sourceTree = "<group>"; };
+		0BF06A241C95139900534083 /* GrooveShark.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = GrooveShark.plist; sourceTree = "<group>"; };
+		0BF06A251C95139900534083 /* HotNewHipHop.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = HotNewHipHop.plist; sourceTree = "<group>"; };
+		0BF06A261C95139900534083 /* HypeMachine.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = HypeMachine.plist; sourceTree = "<group>"; };
+		0BF06A271C95139A00534083 /* iHeartRadio.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = iHeartRadio.plist; sourceTree = "<group>"; };
+		0BF06A281C95139A00534083 /* IndieShuffle.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = IndieShuffle.plist; sourceTree = "<group>"; };
+		0BF06A291C95139A00534083 /* Jango.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Jango.plist; sourceTree = "<group>"; };
+		0BF06A2A1C95139A00534083 /* KollektFm.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = KollektFm.plist; sourceTree = "<group>"; };
+		0BF06A2B1C95139A00534083 /* LastFm.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = LastFm.plist; sourceTree = "<group>"; };
+		0BF06A2C1C95139A00534083 /* LeTournedisque.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = LeTournedisque.plist; sourceTree = "<group>"; };
+		0BF06A2D1C95139A00534083 /* LogitechMediaServer.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = LogitechMediaServer.plist; sourceTree = "<group>"; };
+		0BF06A2E1C95139A00534083 /* MixCloud.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = MixCloud.plist; sourceTree = "<group>"; };
+		0BF06A2F1C95139A00534083 /* MusicForProgramming.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = MusicForProgramming.plist; sourceTree = "<group>"; };
+		0BF06A301C95139A00534083 /* MusicUnlimited.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = MusicUnlimited.plist; sourceTree = "<group>"; };
+		0BF06A311C95139A00534083 /* Netflix.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Netflix.plist; sourceTree = "<group>"; };
+		0BF06A321C95139A00534083 /* NoAdRadio.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = NoAdRadio.plist; sourceTree = "<group>"; };
+		0BF06A331C95139A00534083 /* NoonPacific.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = NoonPacific.plist; sourceTree = "<group>"; };
+		0BF06A341C95139A00534083 /* NRK.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = NRK.plist; sourceTree = "<group>"; };
+		0BF06A351C95139A00534083 /* Odnoklassniki.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Odnoklassniki.plist; sourceTree = "<group>"; };
+		0BF06A361C95139A00534083 /* Overcast.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Overcast.plist; sourceTree = "<group>"; };
+		0BF06A371C95139A00534083 /* Pandora.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Pandora.plist; sourceTree = "<group>"; };
+		0BF06A381C95139A00534083 /* PlexWeb.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = PlexWeb.plist; sourceTree = "<group>"; };
+		0BF06A391C95139A00534083 /* PocketCasts.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = PocketCasts.plist; sourceTree = "<group>"; };
+		0BF06A3A1C95139A00534083 /* Rdio.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Rdio.plist; sourceTree = "<group>"; };
+		0BF06A3B1C95139A00534083 /* Rhapsody.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Rhapsody.plist; sourceTree = "<group>"; };
+		0BF06A3C1C95139A00534083 /* Saavn.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Saavn.plist; sourceTree = "<group>"; };
+		0BF06A3D1C95139A00534083 /* ShufflerFm.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = ShufflerFm.plist; sourceTree = "<group>"; };
+		0BF06A3E1C95139A00534083 /* Slacker.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Slacker.plist; sourceTree = "<group>"; };
+		0BF06A3F1C95139A00534083 /* SomaFm.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = SomaFm.plist; sourceTree = "<group>"; };
+		0BF06A401C95139A00534083 /* Songza.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Songza.plist; sourceTree = "<group>"; };
+		0BF06A411C95139A00534083 /* SoundCloud.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = SoundCloud.plist; sourceTree = "<group>"; };
+		0BF06A421C95139A00534083 /* Spotify.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Spotify.plist; sourceTree = "<group>"; };
+		0BF06A431C95139A00534083 /* Stitcher.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Stitcher.plist; sourceTree = "<group>"; };
+		0BF06A441C95139A00534083 /* Subsonic.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Subsonic.plist; sourceTree = "<group>"; };
+		0BF06A451C95139A00534083 /* Synology.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Synology.plist; sourceTree = "<group>"; };
+		0BF06A461C95139A00534083 /* TidalHiFi.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = TidalHiFi.plist; sourceTree = "<group>"; };
+		0BF06A471C95139A00534083 /* TuneIn.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = TuneIn.plist; sourceTree = "<group>"; };
+		0BF06A481C95139A00534083 /* TwentyTwoTracks.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = TwentyTwoTracks.plist; sourceTree = "<group>"; };
+		0BF06A491C95139A00534083 /* Twitch.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Twitch.plist; sourceTree = "<group>"; };
+		0BF06A4A1C95139A00534083 /* Udemy.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Udemy.plist; sourceTree = "<group>"; };
+		0BF06A4B1C95139A00534083 /* versions.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = versions.plist; sourceTree = "<group>"; };
+		0BF06A4C1C95139A00534083 /* Vessel.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Vessel.plist; sourceTree = "<group>"; };
+		0BF06A4D1C95139A00534083 /* Vimeo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Vimeo.plist; sourceTree = "<group>"; };
+		0BF06A4E1C95139A00534083 /* Vk.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Vk.plist; sourceTree = "<group>"; };
+		0BF06A4F1C95139A00534083 /* WatchaPlay.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = WatchaPlay.plist; sourceTree = "<group>"; };
+		0BF06A501C95139A00534083 /* WonderFm.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = WonderFm.plist; sourceTree = "<group>"; };
+		0BF06A511C95139A00534083 /* XboxMusic.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = XboxMusic.plist; sourceTree = "<group>"; };
+		0BF06A521C95139A00534083 /* YandexMusic.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = YandexMusic.plist; sourceTree = "<group>"; };
+		0BF06A531C95139A00534083 /* YandexRadio.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = YandexRadio.plist; sourceTree = "<group>"; };
+		0BF06A541C95139A00534083 /* Youtube.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Youtube.plist; sourceTree = "<group>"; };
 		0BF06ADB1C9513A800534083 /* BSMediaStrategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSMediaStrategy.h; sourceTree = "<group>"; };
 		0BF06ADC1C9513A800534083 /* BSMediaStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSMediaStrategy.m; sourceTree = "<group>"; };
-		0BF06ADD1C9513A800534083 /* BSStrategyVersionManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = BSStrategyVersionManager.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		0BF06ADE1C9513A800534083 /* BSStrategyVersionManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = BSStrategyVersionManager.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		0BF06ADD1C9513A800534083 /* BSStrategyVersionManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSStrategyVersionManager.h; sourceTree = "<group>"; };
+		0BF06ADE1C9513A800534083 /* BSStrategyVersionManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSStrategyVersionManager.m; sourceTree = "<group>"; };
 		0BF06ADF1C9513A800534083 /* BSTrack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSTrack.h; sourceTree = "<group>"; };
 		0BF06AE01C9513A800534083 /* BSTrack.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSTrack.m; sourceTree = "<group>"; };
-		19F70640AA530B57CAE19126 /* Pods-BeardedSpiceControllers.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeardedSpiceControllers.release.xcconfig"; path = "Pods/Target Support Files/Pods-BeardedSpiceControllers/Pods-BeardedSpiceControllers.release.xcconfig"; sourceTree = "<group>"; };
-		2276A4EDC9C2D1AAD937291D /* Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests/Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.debug.xcconfig"; sourceTree = "<group>"; };
-		2A913DB70FE33880FAD92004 /* Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests/Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.release.xcconfig"; sourceTree = "<group>"; };
-		412BD1821FB849B7F1BABF75 /* Pods-BeardedSpiceControllers-BeardedSpice.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeardedSpiceControllers-BeardedSpice.release.xcconfig"; path = "Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice/Pods-BeardedSpiceControllers-BeardedSpice.release.xcconfig"; sourceTree = "<group>"; };
-		47E7DF3674629C3865366CA8 /* Pods-BeardedSpiceControllers-BeardedSpice.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeardedSpiceControllers-BeardedSpice.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice/Pods-BeardedSpiceControllers-BeardedSpice.debug.xcconfig"; sourceTree = "<group>"; };
-		53666B3CA02A56F052042196 /* libPods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		17C5B63918DB33C0006F38C1 /* beard@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "beard@2x.png"; sourceTree = "<group>"; };
+		17C5B63B18DB3649006F38C1 /* beard-highlighted@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "beard-highlighted@2x.png"; sourceTree = "<group>"; };
+		2299BC537DEC481A9540F7CA /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		28CA978C46A156EA9D1CFA4A /* libPods-BeardedSpiceControllers-BeardedSpice.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BeardedSpiceControllers-BeardedSpice.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		2F6D87D0EA72A7C89F896C4E /* Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests/Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.debug.xcconfig"; sourceTree = "<group>"; };
+		45EC506CE39EEDB80F99EA07 /* libPods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5ECFDCD51CD8F8DE00811169 /* Downcast.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Downcast.h; sourceTree = "<group>"; };
+		5ECFDCD61CD8F8DE00811169 /* DowncastTabAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DowncastTabAdapter.h; sourceTree = "<group>"; };
+		5ECFDCD71CD8F8DE00811169 /* DowncastTabAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DowncastTabAdapter.m; sourceTree = "<group>"; };
 		651967BF1AB3858800B48D3A /* iTunes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = iTunes.h; sourceTree = "<group>"; };
 		651967C01AB3A0B200B48D3A /* iTunesTabAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = iTunesTabAdapter.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		651967C11AB3A0B200B48D3A /* iTunesTabAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = iTunesTabAdapter.m; sourceTree = "<group>"; };
 		652AD3361CC04A7C005396CD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/GeneralPreferencesView.xib; sourceTree = "<group>"; };
 		652AD3371CC04A7C005396CD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/ShortcutsPreferencesView.xib; sourceTree = "<group>"; };
 		652AD3381CC04A7D005396CD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
-		652AD3391CC04ABA005396CD /* Base */ = {isa = PBXFileReference; fileEncoding = 10; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
+		652AD3391CC04ABA005396CD /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6537DAA61AF396DA002F2391 /* NativeAppTabRegistry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NativeAppTabRegistry.h; sourceTree = "<group>"; };
 		6537DAA71AF396DA002F2391 /* NativeAppTabRegistry.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NativeAppTabRegistry.m; sourceTree = "<group>"; };
 		6537DAA91AF508DF002F2391 /* MediaControllerObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MediaControllerObject.h; sourceTree = "<group>"; };
 		6537DAAA1AF508DF002F2391 /* MediaControllerObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MediaControllerObject.m; sourceTree = "<group>"; };
 		653BCACF1AB25DAC0034D27F /* ShortcutsPreferencesViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShortcutsPreferencesViewController.h; sourceTree = "<group>"; };
 		653BCAD01AB25DAC0034D27F /* ShortcutsPreferencesViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ShortcutsPreferencesViewController.m; sourceTree = "<group>"; };
-		655AACA51D3ABFAA00E316EA /* EHCCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EHCCache.h; sourceTree = "<group>"; };
-		655AACA61D3ABFAA00E316EA /* EHCCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EHCCache.m; sourceTree = "<group>"; };
-		655AACA71D3ABFAA00E316EA /* NSArray+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+Utils.h"; sourceTree = "<group>"; };
-		655AACA81D3ABFAA00E316EA /* NSArray+Utils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSArray+Utils.m"; sourceTree = "<group>"; };
 		656A00001C8AD3C800BD29F5 /* DDHidAppleMikey.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDHidAppleMikey.m; sourceTree = "<group>"; };
 		656A00011C8AD3C800BD29F5 /* DDHidAppleRemote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDHidAppleRemote.h; sourceTree = "<group>"; };
 		656A00021C8AD3C800BD29F5 /* DDHidAppleRemote.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDHidAppleRemote.m; sourceTree = "<group>"; };
@@ -240,11 +421,6 @@
 		65A850151C8B065000D54C77 /* BSCService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = BSCService.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		65A8501B1C9330F800D54C77 /* BSCShortcutMonitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = BSCShortcutMonitor.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		65A8501C1C9330F800D54C77 /* BSCShortcutMonitor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = BSCShortcutMonitor.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		65ABBAA41D1EC7D000F882CE /* BSCustomStrategyManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSCustomStrategyManager.h; sourceTree = "<group>"; };
-		65ABBAA51D1EC7D000F882CE /* BSCustomStrategyManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSCustomStrategyManager.m; sourceTree = "<group>"; };
-		65ABBAA81D1FDC5400F882CE /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
-		65ADE6031D169D0C000C29F1 /* EHVerticalCenteredTextField.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EHVerticalCenteredTextField.h; sourceTree = "<group>"; };
-		65ADE6041D169D0C000C29F1 /* EHVerticalCenteredTextField.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EHVerticalCenteredTextField.m; sourceTree = "<group>"; };
 		65B32B8C1AD99D1600F696B9 /* TabAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TabAdapter.h; sourceTree = "<group>"; };
 		65B32B8D1AD99D1600F696B9 /* TabAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TabAdapter.m; sourceTree = "<group>"; };
 		65C511691AED66A700EBA6A5 /* SpotifyTabAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SpotifyTabAdapter.m; sourceTree = "<group>"; };
@@ -252,8 +428,6 @@
 		65C5116C1AED688800EBA6A5 /* Spotify.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Spotify.h; sourceTree = "<group>"; };
 		65C511701AED802B00EBA6A5 /* NativeAppTabAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NativeAppTabAdapter.h; sourceTree = "<group>"; };
 		65C511711AED802B00EBA6A5 /* NativeAppTabAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NativeAppTabAdapter.m; sourceTree = "<group>"; };
-		65D57FCA1D02CBFE0016F270 /* MediaStrategies */ = {isa = PBXFileReference; lastKnownFileType = folder; path = MediaStrategies; sourceTree = "<group>"; };
-		65D57FCF1D02E64F0016F270 /* Debug-Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Debug-Config.xcconfig"; sourceTree = "<group>"; };
 		65E567071B76104300AD2D46 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
 		65E5670C1B76A07700AD2D46 /* BSMediaStrategyEnableButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSMediaStrategyEnableButton.h; sourceTree = "<group>"; };
 		65E5670D1B76A07700AD2D46 /* BSMediaStrategyEnableButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSMediaStrategyEnableButton.m; sourceTree = "<group>"; };
@@ -263,8 +437,8 @@
 		65E567131B775C9300AD2D46 /* BSShortcutView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSShortcutView.m; sourceTree = "<group>"; };
 		65FF756A1B36CEDF00D81CA5 /* BSLaunchAtLogin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSLaunchAtLogin.h; sourceTree = "<group>"; };
 		65FF756B1B36CEDF00D81CA5 /* BSLaunchAtLogin.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSLaunchAtLogin.m; sourceTree = "<group>"; };
-		7FAD2F3C92017C9093D70503 /* libPods-BeardedSpiceControllers.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BeardedSpiceControllers.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		91351FB7426B1A29959CEE4B /* Pods-BeardedSpiceControllers.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeardedSpiceControllers.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BeardedSpiceControllers/Pods-BeardedSpiceControllers.debug.xcconfig"; sourceTree = "<group>"; };
+		7A9EAC832D8E08D9DFB67396 /* Pods-BeardedSpiceControllers.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeardedSpiceControllers.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BeardedSpiceControllers/Pods-BeardedSpiceControllers.debug.xcconfig"; sourceTree = "<group>"; };
+		7F20B81547A29635C2DF0434 /* libPods-BeardedSpiceControllers.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BeardedSpiceControllers.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9679332C1855173100A49AC7 /* BeardedSpice.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BeardedSpice.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9679332F1855173100A49AC7 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		967933321855173100A49AC7 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
@@ -279,12 +453,16 @@
 		9679334D1855173100A49AC7 /* BeardedSpiceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BeardedSpiceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9679334E1855173100A49AC7 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		967933551855173100A49AC7 /* BeardedSpiceTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "BeardedSpiceTests-Info.plist"; sourceTree = "<group>"; };
+		967933591855173100A49AC7 /* BeardedSpiceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = BeardedSpiceTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		9679336318551A8F00A49AC7 /* Chrome.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Chrome.h; sourceTree = "<group>"; };
 		9679336418551BCC00A49AC7 /* ScriptingBridge.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ScriptingBridge.framework; path = System/Library/Frameworks/ScriptingBridge.framework; sourceTree = SDKROOT; };
-		A13F7ACE82D7C5DF91641532 /* libPods-BeardedSpiceControllers-BeardedSpice.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BeardedSpiceControllers-BeardedSpice.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		968406BFD21574C07B747F37 /* Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests/Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.release.xcconfig"; sourceTree = "<group>"; };
+		9F9355D0AD84C962E403B8AB /* Pods-BeardedSpiceControllers.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeardedSpiceControllers.release.xcconfig"; path = "Pods/Target Support Files/Pods-BeardedSpiceControllers/Pods-BeardedSpiceControllers.release.xcconfig"; sourceTree = "<group>"; };
+		CBC84E9024D0B34C3324D861 /* Pods-BeardedSpiceControllers-BeardedSpice.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeardedSpiceControllers-BeardedSpice.release.xcconfig"; path = "Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice/Pods-BeardedSpiceControllers-BeardedSpice.release.xcconfig"; sourceTree = "<group>"; };
 		D09EFF1F1C8CD49E00B24DA9 /* VLCTabAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VLCTabAdapter.m; sourceTree = "<group>"; };
 		D09EFF201C8CD49E00B24DA9 /* VLCTabAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VLCTabAdapter.h; sourceTree = "<group>"; };
 		D09EFF211C8CD49E00B24DA9 /* VLC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VLC.h; sourceTree = "<group>"; };
+		EC34526CCB5D146FD02423F4 /* Pods-BeardedSpiceControllers-BeardedSpice.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeardedSpiceControllers-BeardedSpice.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice/Pods-BeardedSpiceControllers-BeardedSpice.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -294,7 +472,7 @@
 			files = (
 				65A8501A1C8DE9E000D54C77 /* CoreAudio.framework in Frameworks */,
 				65A850191C8DE9D900D54C77 /* Carbon.framework in Frameworks */,
-				57EC5B34F4AD4F87F5D44625 /* libPods-BeardedSpiceControllers.a in Frameworks */,
+				1E1426F8950EBED0E2020816 /* libPods-BeardedSpiceControllers.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -304,8 +482,7 @@
 			files = (
 				9679336518551BCC00A49AC7 /* ScriptingBridge.framework in Frameworks */,
 				967933301855173100A49AC7 /* Cocoa.framework in Frameworks */,
-				0BD1B2F31CD21AA900B72A3E /* JavaScriptCore.framework in Frameworks */,
-				7D8A002D0E49A89BB9CB53DD /* libPods-BeardedSpiceControllers-BeardedSpice.a in Frameworks */,
+				DAD858605B37FF09D3AAD082 /* libPods-BeardedSpiceControllers-BeardedSpice.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -313,16 +490,28 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0BD1B2F41CD21AB100B72A3E /* JavaScriptCore.framework in Frameworks */,
 				967933501855173100A49AC7 /* Cocoa.framework in Frameworks */,
 				9679334F1855173100A49AC7 /* XCTest.framework in Frameworks */,
-				11A36C1600CD983E3627C87A /* libPods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.a in Frameworks */,
+				C7EBE1D19BB5376934A3F6D3 /* libPods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		026BCA1451614966030FD4B5 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				7A9EAC832D8E08D9DFB67396 /* Pods-BeardedSpiceControllers.debug.xcconfig */,
+				9F9355D0AD84C962E403B8AB /* Pods-BeardedSpiceControllers.release.xcconfig */,
+				EC34526CCB5D146FD02423F4 /* Pods-BeardedSpiceControllers-BeardedSpice.debug.xcconfig */,
+				CBC84E9024D0B34C3324D861 /* Pods-BeardedSpiceControllers-BeardedSpice.release.xcconfig */,
+				2F6D87D0EA72A7C89F896C4E /* Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.debug.xcconfig */,
+				968406BFD21574C07B747F37 /* Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
 		0369231B1862934000E04DDB /* Preferences */ = {
 			isa = PBXGroup;
 			children = (
@@ -340,8 +529,6 @@
 				65E5670D1B76A07700AD2D46 /* BSMediaStrategyEnableButton.m */,
 				65E567121B775C9300AD2D46 /* BSShortcutView.h */,
 				65E567131B775C9300AD2D46 /* BSShortcutView.m */,
-				65ADE6031D169D0C000C29F1 /* EHVerticalCenteredTextField.h */,
-				65ADE6041D169D0C000C29F1 /* EHVerticalCenteredTextField.m */,
 			);
 			path = Preferences;
 			sourceTree = "<group>";
@@ -349,6 +536,9 @@
 		03F33EE31857E21100E8F77E /* Tabs */ = {
 			isa = PBXGroup;
 			children = (
+				5ECFDCD51CD8F8DE00811169 /* Downcast.h */,
+				5ECFDCD61CD8F8DE00811169 /* DowncastTabAdapter.h */,
+				5ECFDCD71CD8F8DE00811169 /* DowncastTabAdapter.m */,
 				D09EFF1F1C8CD49E00B24DA9 /* VLCTabAdapter.m */,
 				D09EFF201C8CD49E00B24DA9 /* VLCTabAdapter.h */,
 				D09EFF211C8CD49E00B24DA9 /* VLC.h */,
@@ -375,6 +565,81 @@
 			path = Tabs;
 			sourceTree = "<group>";
 		};
+		0BF06A111C95139900534083 /* MediaStrategies */ = {
+			isa = PBXGroup;
+			children = (
+				0BF06A121C95139900534083 /* AmazonMusic.plist */,
+				0BF06A131C95139900534083 /* Audible.plist */,
+				0BF06A141C95139900534083 /* AudioMack.plist */,
+				0BF06A151C95139900534083 /* BandCamp.plist */,
+				0BF06A161C95139900534083 /* BBCRadio.plist */,
+				0BF06A171C95139900534083 /* Beatguide.plist */,
+				0BF06A181C95139900534083 /* BeatsMusic.plist */,
+				0BF06A191C95139900534083 /* Blitzr.plist */,
+				0BF06A1A1C95139900534083 /* BrainFm.plist */,
+				0BF06A1B1C95139900534083 /* BugsMusic.plist */,
+				0BF06A1C1C95139900534083 /* Chorus.plist */,
+				0BF06A1D1C95139900534083 /* Composed.plist */,
+				0BF06A1E1C95139900534083 /* Coursera.plist */,
+				0BF06A1F1C95139900534083 /* Deezer.plist */,
+				0BF06A201C95139900534083 /* DigitallyImported.plist */,
+				0BF06A211C95139900534083 /* EightTracks.plist */,
+				0BF06A221C95139900534083 /* FocusAtWill.plist */,
+				0BF06A231C95139900534083 /* GoogleMusic.plist */,
+				0BF06A241C95139900534083 /* GrooveShark.plist */,
+				0BF06A251C95139900534083 /* HotNewHipHop.plist */,
+				0BF06A261C95139900534083 /* HypeMachine.plist */,
+				0BF06A271C95139A00534083 /* iHeartRadio.plist */,
+				0BF06A281C95139A00534083 /* IndieShuffle.plist */,
+				0BF06A291C95139A00534083 /* Jango.plist */,
+				0BF06A2A1C95139A00534083 /* KollektFm.plist */,
+				0BF06A2B1C95139A00534083 /* LastFm.plist */,
+				0BF06A2C1C95139A00534083 /* LeTournedisque.plist */,
+				0BF06A2D1C95139A00534083 /* LogitechMediaServer.plist */,
+				0BF06A2E1C95139A00534083 /* MixCloud.plist */,
+				0BF06A2F1C95139A00534083 /* MusicForProgramming.plist */,
+				0BF06A301C95139A00534083 /* MusicUnlimited.plist */,
+				0BF06A311C95139A00534083 /* Netflix.plist */,
+				0BF06A321C95139A00534083 /* NoAdRadio.plist */,
+				0BF06A331C95139A00534083 /* NoonPacific.plist */,
+				0BF06A341C95139A00534083 /* NRK.plist */,
+				0BF06A351C95139A00534083 /* Odnoklassniki.plist */,
+				0BF06A361C95139A00534083 /* Overcast.plist */,
+				0BF06A371C95139A00534083 /* Pandora.plist */,
+				0BF06A381C95139A00534083 /* PlexWeb.plist */,
+				0BF06A391C95139A00534083 /* PocketCasts.plist */,
+				0BF06A3A1C95139A00534083 /* Rdio.plist */,
+				0BF06A3B1C95139A00534083 /* Rhapsody.plist */,
+				0BF06A3C1C95139A00534083 /* Saavn.plist */,
+				0BF06A3D1C95139A00534083 /* ShufflerFm.plist */,
+				0BF06A3E1C95139A00534083 /* Slacker.plist */,
+				0BF06A3F1C95139A00534083 /* SomaFm.plist */,
+				0BF06A401C95139A00534083 /* Songza.plist */,
+				0BF06A411C95139A00534083 /* SoundCloud.plist */,
+				0BF06A421C95139A00534083 /* Spotify.plist */,
+				0BF06A431C95139A00534083 /* Stitcher.plist */,
+				0BF06A441C95139A00534083 /* Subsonic.plist */,
+				0BF06A451C95139A00534083 /* Synology.plist */,
+				0BF06A461C95139A00534083 /* TidalHiFi.plist */,
+				0BF06A471C95139A00534083 /* TuneIn.plist */,
+				0BF06A481C95139A00534083 /* TwentyTwoTracks.plist */,
+				0BF06A491C95139A00534083 /* Twitch.plist */,
+				0BF06A4A1C95139A00534083 /* Udemy.plist */,
+				0BF06A4B1C95139A00534083 /* versions.plist */,
+				0BF06A4C1C95139A00534083 /* Vessel.plist */,
+				0BF06A4D1C95139A00534083 /* Vimeo.plist */,
+				0BF06A4E1C95139A00534083 /* Vk.plist */,
+				0BF06A4F1C95139A00534083 /* WatchaPlay.plist */,
+				0BF06A501C95139A00534083 /* WonderFm.plist */,
+				0BF06A511C95139A00534083 /* XboxMusic.plist */,
+				0BF06A521C95139A00534083 /* YandexMusic.plist */,
+				0BF06A531C95139A00534083 /* YandexRadio.plist */,
+				0BF06A541C95139A00534083 /* Youtube.plist */,
+			);
+			name = MediaStrategies;
+			path = BeardedSpice/MediaStrategies;
+			sourceTree = SOURCE_ROOT;
+		};
 		656A001D1C8AD3E200BD29F5 /* SPMediaKeyTap */ = {
 			isa = PBXGroup;
 			children = (
@@ -389,10 +654,6 @@
 		656A00241C8AD41A00BD29F5 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
-				655AACA51D3ABFAA00E316EA /* EHCCache.h */,
-				655AACA61D3ABFAA00E316EA /* EHCCache.m */,
-				655AACA71D3ABFAA00E316EA /* NSArray+Utils.h */,
-				655AACA81D3ABFAA00E316EA /* NSArray+Utils.m */,
 				656A00251C8AD41A00BD29F5 /* BSTimeout.h */,
 				656A00261C8AD41A00BD29F5 /* BSTimeout.m */,
 				656A00271C8AD41A00BD29F5 /* EHSystemUtils.h */,
@@ -482,7 +743,7 @@
 				967933531855173100A49AC7 /* BeardedSpiceTests */,
 				9679332E1855173100A49AC7 /* Frameworks */,
 				9679332D1855173100A49AC7 /* Products */,
-				C5F7A2FBB1AC4C50850BCEEB /* Pods */,
+				026BCA1451614966030FD4B5 /* Pods */,
 			);
 			indentWidth = 4;
 			sourceTree = "<group>";
@@ -503,16 +764,16 @@
 		9679332E1855173100A49AC7 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				0BD1B2F21CD21AA900B72A3E /* JavaScriptCore.framework */,
 				65E567071B76104300AD2D46 /* CoreAudio.framework */,
 				03F33ECB1855306A00E8F77E /* Carbon.framework */,
 				9679336418551BCC00A49AC7 /* ScriptingBridge.framework */,
 				9679332F1855173100A49AC7 /* Cocoa.framework */,
 				9679334E1855173100A49AC7 /* XCTest.framework */,
 				967933311855173100A49AC7 /* Other Frameworks */,
-				7FAD2F3C92017C9093D70503 /* libPods-BeardedSpiceControllers.a */,
-				A13F7ACE82D7C5DF91641532 /* libPods-BeardedSpiceControllers-BeardedSpice.a */,
-				53666B3CA02A56F052042196 /* libPods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.a */,
+				2299BC537DEC481A9540F7CA /* libPods.a */,
+				7F20B81547A29635C2DF0434 /* libPods-BeardedSpiceControllers.a */,
+				28CA978C46A156EA9D1CFA4A /* libPods-BeardedSpiceControllers-BeardedSpice.a */,
+				45EC506CE39EEDB80F99EA07 /* libPods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -530,22 +791,15 @@
 		967933351855173100A49AC7 /* BeardedSpice */ = {
 			isa = PBXGroup;
 			children = (
-				65ABBAA81D1FDC5400F882CE /* Config.xcconfig */,
-				65D57FCF1D02E64F0016F270 /* Debug-Config.xcconfig */,
-				65D57FCA1D02CBFE0016F270 /* MediaStrategies */,
+				0BF06A111C95139900534083 /* MediaStrategies */,
 				0369231B1862934000E04DDB /* Preferences */,
 				03F33EE31857E21100E8F77E /* Tabs */,
 				03A34920185EA43900C4A62B /* MediaStrategyRegistry.h */,
 				03A34921185EA43900C4A62B /* MediaStrategyRegistry.m */,
 				0BF06ADB1C9513A800534083 /* BSMediaStrategy.h */,
 				0BF06ADC1C9513A800534083 /* BSMediaStrategy.m */,
-				0BE8FFFA1CDA4F5B001A4DDF /* versions.plist */,
 				0BF06ADD1C9513A800534083 /* BSStrategyVersionManager.h */,
 				0BF06ADE1C9513A800534083 /* BSStrategyVersionManager.m */,
-				65ABBAA41D1EC7D000F882CE /* BSCustomStrategyManager.h */,
-				65ABBAA51D1EC7D000F882CE /* BSCustomStrategyManager.m */,
-				0B33014C1CFA643F0090DB67 /* BSStrategyCache.h */,
-				0B33014D1CFA643F0090DB67 /* BSStrategyCache.m */,
 				0BF06ADF1C9513A800534083 /* BSTrack.h */,
 				0BF06AE01C9513A800534083 /* BSTrack.m */,
 				6537DAA61AF396DA002F2391 /* NativeAppTabRegistry.h */,
@@ -566,6 +820,10 @@
 		967933361855173100A49AC7 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				0320C0531868C7A4009591CA /* beard-highlighted.png */,
+				17C5B63B18DB3649006F38C1 /* beard-highlighted@2x.png */,
+				0320C0511868C6C2009591CA /* beard.png */,
+				17C5B63918DB33C0006F38C1 /* beard@2x.png */,
 				030123391868B1F90080115F /* BeardedSpiceUserDefaults.plist */,
 				967933371855173100A49AC7 /* BeardedSpice-Info.plist */,
 				9679333B1855173100A49AC7 /* main.m */,
@@ -578,11 +836,7 @@
 		967933531855173100A49AC7 /* BeardedSpiceTests */ = {
 			isa = PBXGroup;
 			children = (
-				0B1AF3761CCE4D4C0021BBEA /* BSMediaStrategyTests.m */,
-				0B1AF3771CCE4D4C0021BBEA /* BSStrategyMockObject.h */,
-				0B1AF3781CCE4D4C0021BBEA /* BSStrategyMockObject.m */,
-				0B1AF3791CCE4D4C0021BBEA /* BSStrategyTests.m */,
-				0B1AF37C1CCE4D4C0021BBEA /* BSTrackTests.m */,
+				967933591855173100A49AC7 /* BeardedSpiceTests.m */,
 				967933541855173100A49AC7 /* Supporting Files */,
 			);
 			path = BeardedSpiceTests;
@@ -596,19 +850,6 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
-		C5F7A2FBB1AC4C50850BCEEB /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				91351FB7426B1A29959CEE4B /* Pods-BeardedSpiceControllers.debug.xcconfig */,
-				19F70640AA530B57CAE19126 /* Pods-BeardedSpiceControllers.release.xcconfig */,
-				47E7DF3674629C3865366CA8 /* Pods-BeardedSpiceControllers-BeardedSpice.debug.xcconfig */,
-				412BD1821FB849B7F1BABF75 /* Pods-BeardedSpiceControllers-BeardedSpice.release.xcconfig */,
-				2276A4EDC9C2D1AAD937291D /* Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.debug.xcconfig */,
-				2A913DB70FE33880FAD92004 /* Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -616,11 +857,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 656AFFF81C8ACDCF00BD29F5 /* Build configuration list for PBXNativeTarget "BeardedSpiceControllers" */;
 			buildPhases = (
-				19168B7827BBC96768A4C0E7 /* [CP] Check Pods Manifest.lock */,
+				2347A5CF8E47858340D7C44D /* [CP] Check Pods Manifest.lock */,
 				656AFFE61C8ACDCF00BD29F5 /* Sources */,
 				656AFFE71C8ACDCF00BD29F5 /* Frameworks */,
 				656AFFE81C8ACDCF00BD29F5 /* Resources */,
-				899723E2D1D7C2A165079678 /* [CP] Copy Pods Resources */,
+				8449C49435F79BA2F22310E4 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -635,14 +876,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 9679335D1855173100A49AC7 /* Build configuration list for PBXNativeTarget "BeardedSpice" */;
 			buildPhases = (
-				444DB68E61F8ED39440C7D99 /* [CP] Check Pods Manifest.lock */,
+				1B37E2ED2CE348E4A35365B6 /* [CP] Check Pods Manifest.lock */,
 				967933281855173100A49AC7 /* Sources */,
 				967933291855173100A49AC7 /* Frameworks */,
 				9679332A1855173100A49AC7 /* Resources */,
+				B3F72F996C864D30BAFDCE71 /* [CP] Copy Pods Resources */,
 				6564BDB01B74BF9C007030D8 /* Embed Frameworks */,
+				790986C3E0FD0317E1DDA091 /* [CP] Embed Pods Frameworks */,
 				656AFFF91C8ACDCF00BD29F5 /* Embed XPC Services */,
-				49DBE1128D0C0CE893BED11E /* [CP] Embed Pods Frameworks */,
-				503D914487498C5E5D4B381C /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -658,12 +899,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 967933601855173100A49AC7 /* Build configuration list for PBXNativeTarget "BeardedSpiceTests" */;
 			buildPhases = (
-				AB9AD96DE64B6D494415BFF9 /* [CP] Check Pods Manifest.lock */,
+				0F084B328AE6B23242C3A83D /* [CP] Check Pods Manifest.lock */,
 				967933491855173100A49AC7 /* Sources */,
 				9679334A1855173100A49AC7 /* Frameworks */,
 				9679334B1855173100A49AC7 /* Resources */,
-				261B1E7D9347603186A50C0D /* [CP] Embed Pods Frameworks */,
-				189AA939D297EACACE65A248 /* [CP] Copy Pods Resources */,
+				5A7D0CA7032ECC0C24582AAF /* [CP] Embed Pods Frameworks */,
+				AAF2584D239BD6B936387DAD /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -716,6 +957,73 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0BF06AAC1C95139A00534083 /* ShufflerFm.plist in Resources */,
+				0BF06AC41C95139A00534083 /* Twitch.plist in Resources */,
+				0BF06A6E1C95139A00534083 /* Coursera.plist in Resources */,
+				0BF06A941C95139A00534083 /* Netflix.plist in Resources */,
+				0BF06A701C95139A00534083 /* Deezer.plist in Resources */,
+				0BF06A8E1C95139A00534083 /* MixCloud.plist in Resources */,
+				0BF06ABA1C95139A00534083 /* Subsonic.plist in Resources */,
+				0BF06A921C95139A00534083 /* MusicUnlimited.plist in Resources */,
+				0BF06AC01C95139A00534083 /* TuneIn.plist in Resources */,
+				0BF06A9E1C95139A00534083 /* Overcast.plist in Resources */,
+				0BF06ADA1C95139A00534083 /* Youtube.plist in Resources */,
+				0BF06A721C95139A00534083 /* DigitallyImported.plist in Resources */,
+				0BF06AD41C95139A00534083 /* XboxMusic.plist in Resources */,
+				0BF06A621C95139A00534083 /* BeatsMusic.plist in Resources */,
+				0BF06AB61C95139A00534083 /* Spotify.plist in Resources */,
+				0BF06ACE1C95139A00534083 /* Vk.plist in Resources */,
+				0BF06A9A1C95139A00534083 /* NRK.plist in Resources */,
+				0BF06A741C95139A00534083 /* EightTracks.plist in Resources */,
+				0BF06A5E1C95139A00534083 /* BBCRadio.plist in Resources */,
+				0BF06A561C95139A00534083 /* AmazonMusic.plist in Resources */,
+				0BF06AA81C95139A00534083 /* Rhapsody.plist in Resources */,
+				0BF06ABC1C95139A00534083 /* Synology.plist in Resources */,
+				0BF06A681C95139A00534083 /* BugsMusic.plist in Resources */,
+				0BF06A581C95139A00534083 /* Audible.plist in Resources */,
+				0BF06A8A1C95139A00534083 /* LeTournedisque.plist in Resources */,
+				0BF06AA61C95139A00534083 /* Rdio.plist in Resources */,
+				0BF06AC81C95139A00534083 /* versions.plist in Resources */,
+				0BF06AA21C95139A00534083 /* PlexWeb.plist in Resources */,
+				0BF06ACC1C95139A00534083 /* Vimeo.plist in Resources */,
+				0BF06AD21C95139A00534083 /* WonderFm.plist in Resources */,
+				0BF06A7E1C95139A00534083 /* HypeMachine.plist in Resources */,
+				0BF06AD01C95139A00534083 /* WatchaPlay.plist in Resources */,
+				0BF06A981C95139A00534083 /* NoonPacific.plist in Resources */,
+				0BF06AC21C95139A00534083 /* TwentyTwoTracks.plist in Resources */,
+				0BF06A961C95139A00534083 /* NoAdRadio.plist in Resources */,
+				0BF06AA01C95139A00534083 /* Pandora.plist in Resources */,
+				0BF06AB21C95139A00534083 /* Songza.plist in Resources */,
+				0BF06AAA1C95139A00534083 /* Saavn.plist in Resources */,
+				0BF06AAE1C95139A00534083 /* Slacker.plist in Resources */,
+				0BF06ACA1C95139A00534083 /* Vessel.plist in Resources */,
+				0BF06AB41C95139A00534083 /* SoundCloud.plist in Resources */,
+				0BF06A781C95139A00534083 /* GoogleMusic.plist in Resources */,
+				0BF06AD61C95139A00534083 /* YandexMusic.plist in Resources */,
+				0BF06A6A1C95139A00534083 /* Chorus.plist in Resources */,
+				0BF06A7A1C95139A00534083 /* GrooveShark.plist in Resources */,
+				0BF06A5C1C95139A00534083 /* BandCamp.plist in Resources */,
+				0BF06A901C95139A00534083 /* MusicForProgramming.plist in Resources */,
+				0BF06A661C95139A00534083 /* BrainFm.plist in Resources */,
+				0BF06AD81C95139A00534083 /* YandexRadio.plist in Resources */,
+				0BF06A641C95139A00534083 /* Blitzr.plist in Resources */,
+				0BF06A8C1C95139A00534083 /* LogitechMediaServer.plist in Resources */,
+				0BF06AB01C95139A00534083 /* SomaFm.plist in Resources */,
+				0BF06A761C95139A00534083 /* FocusAtWill.plist in Resources */,
+				0BF06A821C95139A00534083 /* IndieShuffle.plist in Resources */,
+				0BF06A861C95139A00534083 /* KollektFm.plist in Resources */,
+				0BF06ABE1C95139A00534083 /* TidalHiFi.plist in Resources */,
+				0BF06A5A1C95139A00534083 /* AudioMack.plist in Resources */,
+				0BF06A7C1C95139A00534083 /* HotNewHipHop.plist in Resources */,
+				0BF06A9C1C95139A00534083 /* Odnoklassniki.plist in Resources */,
+				0BF06A881C95139A00534083 /* LastFm.plist in Resources */,
+				0BF06AC61C95139A00534083 /* Udemy.plist in Resources */,
+				0BF06A841C95139A00534083 /* Jango.plist in Resources */,
+				0BF06A6C1C95139A00534083 /* Composed.plist in Resources */,
+				0BF06AB81C95139A00534083 /* Stitcher.plist in Resources */,
+				0BF06A601C95139A00534083 /* Beatguide.plist in Resources */,
+				0BF06A801C95139A00534083 /* iHeartRadio.plist in Resources */,
+				0BF06AA41C95139A00534083 /* PocketCasts.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -723,14 +1031,83 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0BF06AA31C95139A00534083 /* PocketCasts.plist in Resources */,
+				0BF06A6F1C95139A00534083 /* Deezer.plist in Resources */,
+				0BF06AA91C95139A00534083 /* Saavn.plist in Resources */,
+				0BF06A8D1C95139A00534083 /* MixCloud.plist in Resources */,
 				967933481855173100A49AC7 /* Images.xcassets in Resources */,
+				0BF06AA51C95139A00534083 /* Rdio.plist in Resources */,
+				0BF06AAD1C95139A00534083 /* Slacker.plist in Resources */,
+				0BF06ABF1C95139A00534083 /* TuneIn.plist in Resources */,
+				0BF06AD91C95139A00534083 /* Youtube.plist in Resources */,
+				0BF06A9F1C95139A00534083 /* Pandora.plist in Resources */,
+				0BF06A811C95139A00534083 /* IndieShuffle.plist in Resources */,
 				65EE28A11AB6003B00EFC886 /* ShortcutsPreferencesView.xib in Resources */,
+				0BF06A5D1C95139A00534083 /* BBCRadio.plist in Resources */,
+				0BF06A571C95139A00534083 /* Audible.plist in Resources */,
+				0BF06A8F1C95139A00534083 /* MusicForProgramming.plist in Resources */,
+				0BF06A951C95139A00534083 /* NoAdRadio.plist in Resources */,
+				0BF06A851C95139A00534083 /* KollektFm.plist in Resources */,
+				0BF06A7F1C95139A00534083 /* iHeartRadio.plist in Resources */,
+				0BF06AB11C95139A00534083 /* Songza.plist in Resources */,
+				0BF06AD11C95139A00534083 /* WonderFm.plist in Resources */,
+				0BF06A6B1C95139A00534083 /* Composed.plist in Resources */,
+				0BF06A931C95139A00534083 /* Netflix.plist in Resources */,
+				0BF06A7D1C95139A00534083 /* HypeMachine.plist in Resources */,
+				0BF06A8B1C95139A00534083 /* LogitechMediaServer.plist in Resources */,
 				0B355EF71CBEA3350089C2B3 /* Localizable.strings in Resources */,
+				0BF06ABD1C95139A00534083 /* TidalHiFi.plist in Resources */,
+				0BF06AAF1C95139A00534083 /* SomaFm.plist in Resources */,
+				0320C0521868C6C2009591CA /* beard.png in Resources */,
 				0301233A1868B1F90080115F /* BeardedSpiceUserDefaults.plist in Resources */,
+				0BF06A751C95139A00534083 /* FocusAtWill.plist in Resources */,
+				0BF06A771C95139A00534083 /* GoogleMusic.plist in Resources */,
+				0BF06ACF1C95139A00534083 /* WatchaPlay.plist in Resources */,
+				0BF06ACB1C95139A00534083 /* Vimeo.plist in Resources */,
+				0BF06AC11C95139A00534083 /* TwentyTwoTracks.plist in Resources */,
+				0BF06A711C95139A00534083 /* DigitallyImported.plist in Resources */,
+				0BF06AD31C95139A00534083 /* XboxMusic.plist in Resources */,
+				0BF06A911C95139A00534083 /* MusicUnlimited.plist in Resources */,
+				0BF06A971C95139A00534083 /* NoonPacific.plist in Resources */,
+				0BF06A7B1C95139A00534083 /* HotNewHipHop.plist in Resources */,
 				65EE289E1AB6003800EFC886 /* GeneralPreferencesView.xib in Resources */,
-				65D57FCB1D02CBFE0016F270 /* MediaStrategies in Resources */,
+				0BF06AA71C95139A00534083 /* Rhapsody.plist in Resources */,
+				0320C0541868C7A4009591CA /* beard-highlighted.png in Resources */,
+				0BF06A551C95139A00534083 /* AmazonMusic.plist in Resources */,
+				0BF06A791C95139A00534083 /* GrooveShark.plist in Resources */,
 				967933461855173100A49AC7 /* MainMenu.xib in Resources */,
-				0BE800771CDA4F5B001A4DDF /* versions.plist in Resources */,
+				0BF06AB71C95139A00534083 /* Stitcher.plist in Resources */,
+				0BF06A611C95139A00534083 /* BeatsMusic.plist in Resources */,
+				0BF06AA11C95139A00534083 /* PlexWeb.plist in Resources */,
+				17C5B63C18DB3649006F38C1 /* beard-highlighted@2x.png in Resources */,
+				0BF06AC31C95139A00534083 /* Twitch.plist in Resources */,
+				0BF06AB51C95139A00534083 /* Spotify.plist in Resources */,
+				0BF06AD51C95139A00534083 /* YandexMusic.plist in Resources */,
+				0BF06A9B1C95139A00534083 /* Odnoklassniki.plist in Resources */,
+				0BF06A5F1C95139A00534083 /* Beatguide.plist in Resources */,
+				17C5B63A18DB33C0006F38C1 /* beard@2x.png in Resources */,
+				0BF06A651C95139A00534083 /* BrainFm.plist in Resources */,
+				0BF06AAB1C95139A00534083 /* ShufflerFm.plist in Resources */,
+				0BF06A5B1C95139A00534083 /* BandCamp.plist in Resources */,
+				0BF06A991C95139A00534083 /* NRK.plist in Resources */,
+				0BF06A891C95139A00534083 /* LeTournedisque.plist in Resources */,
+				0BF06A9D1C95139A00534083 /* Overcast.plist in Resources */,
+				0BF06ABB1C95139A00534083 /* Synology.plist in Resources */,
+				0BF06AB91C95139A00534083 /* Subsonic.plist in Resources */,
+				0BF06A831C95139A00534083 /* Jango.plist in Resources */,
+				0BF06A631C95139A00534083 /* Blitzr.plist in Resources */,
+				0BF06A591C95139A00534083 /* AudioMack.plist in Resources */,
+				0BF06AC51C95139A00534083 /* Udemy.plist in Resources */,
+				0BF06AD71C95139A00534083 /* YandexRadio.plist in Resources */,
+				0BF06A871C95139A00534083 /* LastFm.plist in Resources */,
+				0BF06AC71C95139A00534083 /* versions.plist in Resources */,
+				0BF06A691C95139A00534083 /* Chorus.plist in Resources */,
+				0BF06A6D1C95139A00534083 /* Coursera.plist in Resources */,
+				0BF06AC91C95139A00534083 /* Vessel.plist in Resources */,
+				0BF06A731C95139A00534083 /* EightTracks.plist in Resources */,
+				0BF06A671C95139A00534083 /* BugsMusic.plist in Resources */,
+				0BF06AB31C95139A00534083 /* SoundCloud.plist in Resources */,
+				0BF06ACD1C95139A00534083 /* Vk.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -738,30 +1115,13 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				65D57FCC1D02CC250016F270 /* MediaStrategies in Resources */,
-				0BE800781CDA4F5B001A4DDF /* versions.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		189AA939D297EACACE65A248 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests/Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		19168B7827BBC96768A4C0E7 /* [CP] Check Pods Manifest.lock */ = {
+		0F084B328AE6B23242C3A83D /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -773,10 +1133,40 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice/Pods-BeardedSpiceControllers-BeardedSpice-resources.sh\"\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		261B1E7D9347603186A50C0D /* [CP] Embed Pods Frameworks */ = {
+		1B37E2ED2CE348E4A35365B6 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		2347A5CF8E47858340D7C44D /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		5A7D0CA7032ECC0C24582AAF /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -791,22 +1181,7 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests/Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		444DB68E61F8ED39440C7D99 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice/Pods-BeardedSpiceControllers-BeardedSpice-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		49DBE1128D0C0CE893BED11E /* [CP] Embed Pods Frameworks */ = {
+		790986C3E0FD0317E1DDA091 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -821,7 +1196,37 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice/Pods-BeardedSpiceControllers-BeardedSpice-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		503D914487498C5E5D4B381C /* [CP] Copy Pods Resources */ = {
+		8449C49435F79BA2F22310E4 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-BeardedSpiceControllers/Pods-BeardedSpiceControllers-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		AAF2584D239BD6B936387DAD /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests/Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B3F72F996C864D30BAFDCE71 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -836,36 +1241,6 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice/Pods-BeardedSpiceControllers-BeardedSpice-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		899723E2D1D7C2A165079678 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		AB9AD96DE64B6D494415BFF9 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -873,7 +1248,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0BF9CAE71CFFDB2F00E9986B /* NSString+Utils.m in Sources */,
 				656A00141C8AD3C800BD29F5 /* DDHidAppleRemote.m in Sources */,
 				656A00231C8AD3E200BD29F5 /* SPMediaKeyTap.m in Sources */,
 				656A00321C8AD41A00BD29F5 /* EHSystemUtils.m in Sources */,
@@ -881,6 +1255,7 @@
 				65A850161C8B065000D54C77 /* BSCService.m in Sources */,
 				656AFFF11C8ACDCF00BD29F5 /* main.m in Sources */,
 				65A8501D1C9330F800D54C77 /* BSCShortcutMonitor.m in Sources */,
+				656A00361C8AD41A00BD29F5 /* NSString+Utils.m in Sources */,
 				656A00221C8AD3E200BD29F5 /* NSObject+SPInvocationGrabbing.m in Sources */,
 				656A003E1C8B01BC00BD29F5 /* BSSharedDefaults.m in Sources */,
 				656A001C1C8AD3C800BD29F5 /* NSXReturnThrowError.m in Sources */,
@@ -903,11 +1278,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5ECFDCD81CD8F8DE00811169 /* DowncastTabAdapter.m in Sources */,
 				0369231F1862936600E04DDB /* GeneralPreferencesViewController.m in Sources */,
 				0BF06AE51C9513A800534083 /* BSTrack.m in Sources */,
-				655AACAA1D3ABFAA00E316EA /* NSArray+Utils.m in Sources */,
 				967933431855173100A49AC7 /* AppDelegate.m in Sources */,
-				65ADE6051D169D0C000C29F1 /* EHVerticalCenteredTextField.m in Sources */,
 				65E567111B76AE3A00AD2D46 /* BSPreferencesWindowController.m in Sources */,
 				6537DAAD1AF6E666002F2391 /* SpotifyTabAdapter.m in Sources */,
 				D09EFF221C8CD49E00B24DA9 /* VLCTabAdapter.m in Sources */,
@@ -922,7 +1296,6 @@
 				03F33EF01857E59B00E8F77E /* SafariTabAdapter.m in Sources */,
 				6588CF461B3584A700A3CBAD /* VOXTabAdapter.m in Sources */,
 				656A00311C8AD41A00BD29F5 /* EHSystemUtils.m in Sources */,
-				65ABBAA61D1EC7D000F882CE /* BSCustomStrategyManager.m in Sources */,
 				0BF06AE11C9513A800534083 /* BSMediaStrategy.m in Sources */,
 				656A00331C8AD41A00BD29F5 /* NSException+Utils.m in Sources */,
 				65E567141B775C9300AD2D46 /* BSShortcutView.m in Sources */,
@@ -932,8 +1305,6 @@
 				6537DAA81AF396DA002F2391 /* NativeAppTabRegistry.m in Sources */,
 				65B32B8E1AD99D1600F696B9 /* TabAdapter.m in Sources */,
 				03F33EED1857E3C000E8F77E /* ChromeTabAdapter.m in Sources */,
-				655AACA91D3ABFAA00E316EA /* EHCCache.m in Sources */,
-				0B33014E1CFA643F0090DB67 /* BSStrategyCache.m in Sources */,
 				656A002F1C8AD41A00BD29F5 /* BSTimeout.m in Sources */,
 				0BF06AE31C9513A800534083 /* BSStrategyVersionManager.m in Sources */,
 				6537DAAB1AF508DF002F2391 /* MediaControllerObject.m in Sources */,
@@ -944,13 +1315,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0B1AF37F1CCE4D4C0021BBEA /* BSStrategyMockObject.m in Sources */,
-				0B1AF37E1CCE4D4C0021BBEA /* BSMediaStrategyTests.m in Sources */,
-				0B33014F1CFA643F0090DB67 /* BSStrategyCache.m in Sources */,
-				0B1AF3831CCE4D4C0021BBEA /* BSTrackTests.m in Sources */,
-				65D57FCE1D02CD140016F270 /* BSMediaStrategy.m in Sources */,
-				65D57FCD1D02CCB00016F270 /* NSURL+Utils.m in Sources */,
-				0B1AF3801CCE4D4C0021BBEA /* BSStrategyTests.m in Sources */,
+				9679335A1855173100A49AC7 /* BeardedSpiceTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1007,17 +1372,18 @@
 /* Begin XCBuildConfiguration section */
 		656AFFF61C8ACDCF00BD29F5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 91351FB7426B1A29959CEE4B /* Pods-BeardedSpiceControllers.debug.xcconfig */;
+			baseConfigurationReference = 7A9EAC832D8E08D9DFB67396 /* Pods-BeardedSpiceControllers.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = BeardedSpiceControllers/Info.plist;
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.beardedspice.BeardedSpiceControllers;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1027,17 +1393,18 @@
 		};
 		656AFFF71C8ACDCF00BD29F5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 19F70640AA530B57CAE19126 /* Pods-BeardedSpiceControllers.release.xcconfig */;
+			baseConfigurationReference = 9F9355D0AD84C962E403B8AB /* Pods-BeardedSpiceControllers.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = BeardedSpiceControllers/Info.plist;
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.beardedspice.BeardedSpiceControllers;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1047,7 +1414,6 @@
 		};
 		9679335B1855173100A49AC7 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 65D57FCF1D02E64F0016F270 /* Debug-Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -1070,7 +1436,6 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
-					"JSC_OBJC_API_ENABLED=1",
 					"$(inherited)",
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
@@ -1080,7 +1445,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
 			};
@@ -1088,7 +1453,6 @@
 		};
 		9679335C1855173100A49AC7 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 65ABBAA81D1FDC5400F882CE /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -1108,29 +1472,25 @@
 				ENABLE_NS_ASSERTIONS = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"JSC_OBJC_API_ENABLED=1",
-					"$(inherited)",
-				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				SDKROOT = macosx;
 			};
 			name = Release;
 		};
 		9679335E1855173100A49AC7 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 47E7DF3674629C3865366CA8 /* Pods-BeardedSpiceControllers-BeardedSpice.debug.xcconfig */;
+			baseConfigurationReference = EC34526CCB5D146FD02423F4 /* Pods-BeardedSpiceControllers-BeardedSpice.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1148,12 +1508,12 @@
 		};
 		9679335F1855173100A49AC7 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 412BD1821FB849B7F1BABF75 /* Pods-BeardedSpiceControllers-BeardedSpice.release.xcconfig */;
+			baseConfigurationReference = CBC84E9024D0B34C3324D861 /* Pods-BeardedSpiceControllers-BeardedSpice.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1171,10 +1531,9 @@
 		};
 		967933611855173100A49AC7 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2276A4EDC9C2D1AAD937291D /* Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.debug.xcconfig */;
+			baseConfigurationReference = 2F6D87D0EA72A7C89F896C4E /* Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = YES;
-				BUNDLE_LOADER = "$(TEST_HOST)";
+				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/BeardedSpice.app/Contents/MacOS/BeardedSpice";
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -1184,21 +1543,23 @@
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "BeardedSpice/BeardedSpice-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
 				INFOPLIST_FILE = "BeardedSpiceTests/BeardedSpiceTests-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "foo.bar.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = BeardedSpiceTests;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BeardedSpice.app/Contents/MacOS/BeardedSpice";
-				USER_HEADER_SEARCH_PATHS = "";
+				TEST_HOST = "$(BUNDLE_LOADER)";
 				WRAPPER_EXTENSION = xctest;
 			};
 			name = Debug;
 		};
 		967933621855173100A49AC7 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2A913DB70FE33880FAD92004 /* Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.release.xcconfig */;
+			baseConfigurationReference = 968406BFD21574C07B747F37 /* Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = YES;
-				BUNDLE_LOADER = "$(TEST_HOST)";
+				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/BeardedSpice.app/Contents/MacOS/BeardedSpice";
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -1211,7 +1572,7 @@
 				INFOPLIST_FILE = "BeardedSpiceTests/BeardedSpiceTests-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "foo.bar.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = BeardedSpiceTests;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BeardedSpice.app/Contents/MacOS/BeardedSpice";
+				TEST_HOST = "$(BUNDLE_LOADER)";
 				WRAPPER_EXTENSION = xctest;
 			};
 			name = Release;

--- a/BeardedSpice.xcodeproj/project.pbxproj
+++ b/BeardedSpice.xcodeproj/project.pbxproj
@@ -8,159 +8,35 @@
 
 /* Begin PBXBuildFile section */
 		0301233A1868B1F90080115F /* BeardedSpiceUserDefaults.plist in Resources */ = {isa = PBXBuildFile; fileRef = 030123391868B1F90080115F /* BeardedSpiceUserDefaults.plist */; };
-		0320C0521868C6C2009591CA /* beard.png in Resources */ = {isa = PBXBuildFile; fileRef = 0320C0511868C6C2009591CA /* beard.png */; };
-		0320C0541868C7A4009591CA /* beard-highlighted.png in Resources */ = {isa = PBXBuildFile; fileRef = 0320C0531868C7A4009591CA /* beard-highlighted.png */; };
 		0369231F1862936600E04DDB /* GeneralPreferencesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0369231D1862936600E04DDB /* GeneralPreferencesViewController.m */; };
 		03A34922185EA43900C4A62B /* MediaStrategyRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 03A34921185EA43900C4A62B /* MediaStrategyRegistry.m */; };
 		03F33EED1857E3C000E8F77E /* ChromeTabAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 03F33EEC1857E3C000E8F77E /* ChromeTabAdapter.m */; };
 		03F33EF01857E59B00E8F77E /* SafariTabAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 03F33EEF1857E59B00E8F77E /* SafariTabAdapter.m */; };
+		0B1AF37E1CCE4D4C0021BBEA /* BSMediaStrategyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B1AF3761CCE4D4C0021BBEA /* BSMediaStrategyTests.m */; };
+		0B1AF37F1CCE4D4C0021BBEA /* BSStrategyMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B1AF3781CCE4D4C0021BBEA /* BSStrategyMockObject.m */; };
+		0B1AF3801CCE4D4C0021BBEA /* BSStrategyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B1AF3791CCE4D4C0021BBEA /* BSStrategyTests.m */; };
+		0B1AF3831CCE4D4C0021BBEA /* BSTrackTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B1AF37C1CCE4D4C0021BBEA /* BSTrackTests.m */; };
+		0B33014E1CFA643F0090DB67 /* BSStrategyCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B33014D1CFA643F0090DB67 /* BSStrategyCache.m */; };
+		0B33014F1CFA643F0090DB67 /* BSStrategyCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B33014D1CFA643F0090DB67 /* BSStrategyCache.m */; };
 		0B355EF71CBEA3350089C2B3 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 0B355EF51CBEA3350089C2B3 /* Localizable.strings */; };
-		0BF06A551C95139A00534083 /* AmazonMusic.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A121C95139900534083 /* AmazonMusic.plist */; };
-		0BF06A561C95139A00534083 /* AmazonMusic.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A121C95139900534083 /* AmazonMusic.plist */; };
-		0BF06A571C95139A00534083 /* Audible.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A131C95139900534083 /* Audible.plist */; };
-		0BF06A581C95139A00534083 /* Audible.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A131C95139900534083 /* Audible.plist */; };
-		0BF06A591C95139A00534083 /* AudioMack.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A141C95139900534083 /* AudioMack.plist */; };
-		0BF06A5A1C95139A00534083 /* AudioMack.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A141C95139900534083 /* AudioMack.plist */; };
-		0BF06A5B1C95139A00534083 /* BandCamp.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A151C95139900534083 /* BandCamp.plist */; };
-		0BF06A5C1C95139A00534083 /* BandCamp.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A151C95139900534083 /* BandCamp.plist */; };
-		0BF06A5D1C95139A00534083 /* BBCRadio.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A161C95139900534083 /* BBCRadio.plist */; };
-		0BF06A5E1C95139A00534083 /* BBCRadio.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A161C95139900534083 /* BBCRadio.plist */; };
-		0BF06A5F1C95139A00534083 /* Beatguide.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A171C95139900534083 /* Beatguide.plist */; };
-		0BF06A601C95139A00534083 /* Beatguide.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A171C95139900534083 /* Beatguide.plist */; };
-		0BF06A611C95139A00534083 /* BeatsMusic.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A181C95139900534083 /* BeatsMusic.plist */; };
-		0BF06A621C95139A00534083 /* BeatsMusic.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A181C95139900534083 /* BeatsMusic.plist */; };
-		0BF06A631C95139A00534083 /* Blitzr.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A191C95139900534083 /* Blitzr.plist */; };
-		0BF06A641C95139A00534083 /* Blitzr.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A191C95139900534083 /* Blitzr.plist */; };
-		0BF06A651C95139A00534083 /* BrainFm.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A1A1C95139900534083 /* BrainFm.plist */; };
-		0BF06A661C95139A00534083 /* BrainFm.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A1A1C95139900534083 /* BrainFm.plist */; };
-		0BF06A671C95139A00534083 /* BugsMusic.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A1B1C95139900534083 /* BugsMusic.plist */; };
-		0BF06A681C95139A00534083 /* BugsMusic.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A1B1C95139900534083 /* BugsMusic.plist */; };
-		0BF06A691C95139A00534083 /* Chorus.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A1C1C95139900534083 /* Chorus.plist */; };
-		0BF06A6A1C95139A00534083 /* Chorus.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A1C1C95139900534083 /* Chorus.plist */; };
-		0BF06A6B1C95139A00534083 /* Composed.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A1D1C95139900534083 /* Composed.plist */; };
-		0BF06A6C1C95139A00534083 /* Composed.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A1D1C95139900534083 /* Composed.plist */; };
-		0BF06A6D1C95139A00534083 /* Coursera.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A1E1C95139900534083 /* Coursera.plist */; };
-		0BF06A6E1C95139A00534083 /* Coursera.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A1E1C95139900534083 /* Coursera.plist */; };
-		0BF06A6F1C95139A00534083 /* Deezer.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A1F1C95139900534083 /* Deezer.plist */; };
-		0BF06A701C95139A00534083 /* Deezer.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A1F1C95139900534083 /* Deezer.plist */; };
-		0BF06A711C95139A00534083 /* DigitallyImported.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A201C95139900534083 /* DigitallyImported.plist */; };
-		0BF06A721C95139A00534083 /* DigitallyImported.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A201C95139900534083 /* DigitallyImported.plist */; };
-		0BF06A731C95139A00534083 /* EightTracks.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A211C95139900534083 /* EightTracks.plist */; };
-		0BF06A741C95139A00534083 /* EightTracks.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A211C95139900534083 /* EightTracks.plist */; };
-		0BF06A751C95139A00534083 /* FocusAtWill.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A221C95139900534083 /* FocusAtWill.plist */; };
-		0BF06A761C95139A00534083 /* FocusAtWill.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A221C95139900534083 /* FocusAtWill.plist */; };
-		0BF06A771C95139A00534083 /* GoogleMusic.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A231C95139900534083 /* GoogleMusic.plist */; };
-		0BF06A781C95139A00534083 /* GoogleMusic.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A231C95139900534083 /* GoogleMusic.plist */; };
-		0BF06A791C95139A00534083 /* GrooveShark.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A241C95139900534083 /* GrooveShark.plist */; };
-		0BF06A7A1C95139A00534083 /* GrooveShark.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A241C95139900534083 /* GrooveShark.plist */; };
-		0BF06A7B1C95139A00534083 /* HotNewHipHop.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A251C95139900534083 /* HotNewHipHop.plist */; };
-		0BF06A7C1C95139A00534083 /* HotNewHipHop.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A251C95139900534083 /* HotNewHipHop.plist */; };
-		0BF06A7D1C95139A00534083 /* HypeMachine.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A261C95139900534083 /* HypeMachine.plist */; };
-		0BF06A7E1C95139A00534083 /* HypeMachine.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A261C95139900534083 /* HypeMachine.plist */; };
-		0BF06A7F1C95139A00534083 /* iHeartRadio.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A271C95139A00534083 /* iHeartRadio.plist */; };
-		0BF06A801C95139A00534083 /* iHeartRadio.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A271C95139A00534083 /* iHeartRadio.plist */; };
-		0BF06A811C95139A00534083 /* IndieShuffle.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A281C95139A00534083 /* IndieShuffle.plist */; };
-		0BF06A821C95139A00534083 /* IndieShuffle.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A281C95139A00534083 /* IndieShuffle.plist */; };
-		0BF06A831C95139A00534083 /* Jango.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A291C95139A00534083 /* Jango.plist */; };
-		0BF06A841C95139A00534083 /* Jango.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A291C95139A00534083 /* Jango.plist */; };
-		0BF06A851C95139A00534083 /* KollektFm.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A2A1C95139A00534083 /* KollektFm.plist */; };
-		0BF06A861C95139A00534083 /* KollektFm.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A2A1C95139A00534083 /* KollektFm.plist */; };
-		0BF06A871C95139A00534083 /* LastFm.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A2B1C95139A00534083 /* LastFm.plist */; };
-		0BF06A881C95139A00534083 /* LastFm.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A2B1C95139A00534083 /* LastFm.plist */; };
-		0BF06A891C95139A00534083 /* LeTournedisque.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A2C1C95139A00534083 /* LeTournedisque.plist */; };
-		0BF06A8A1C95139A00534083 /* LeTournedisque.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A2C1C95139A00534083 /* LeTournedisque.plist */; };
-		0BF06A8B1C95139A00534083 /* LogitechMediaServer.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A2D1C95139A00534083 /* LogitechMediaServer.plist */; };
-		0BF06A8C1C95139A00534083 /* LogitechMediaServer.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A2D1C95139A00534083 /* LogitechMediaServer.plist */; };
-		0BF06A8D1C95139A00534083 /* MixCloud.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A2E1C95139A00534083 /* MixCloud.plist */; };
-		0BF06A8E1C95139A00534083 /* MixCloud.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A2E1C95139A00534083 /* MixCloud.plist */; };
-		0BF06A8F1C95139A00534083 /* MusicForProgramming.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A2F1C95139A00534083 /* MusicForProgramming.plist */; };
-		0BF06A901C95139A00534083 /* MusicForProgramming.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A2F1C95139A00534083 /* MusicForProgramming.plist */; };
-		0BF06A911C95139A00534083 /* MusicUnlimited.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A301C95139A00534083 /* MusicUnlimited.plist */; };
-		0BF06A921C95139A00534083 /* MusicUnlimited.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A301C95139A00534083 /* MusicUnlimited.plist */; };
-		0BF06A931C95139A00534083 /* Netflix.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A311C95139A00534083 /* Netflix.plist */; };
-		0BF06A941C95139A00534083 /* Netflix.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A311C95139A00534083 /* Netflix.plist */; };
-		0BF06A951C95139A00534083 /* NoAdRadio.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A321C95139A00534083 /* NoAdRadio.plist */; };
-		0BF06A961C95139A00534083 /* NoAdRadio.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A321C95139A00534083 /* NoAdRadio.plist */; };
-		0BF06A971C95139A00534083 /* NoonPacific.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A331C95139A00534083 /* NoonPacific.plist */; };
-		0BF06A981C95139A00534083 /* NoonPacific.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A331C95139A00534083 /* NoonPacific.plist */; };
-		0BF06A991C95139A00534083 /* NRK.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A341C95139A00534083 /* NRK.plist */; };
-		0BF06A9A1C95139A00534083 /* NRK.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A341C95139A00534083 /* NRK.plist */; };
-		0BF06A9B1C95139A00534083 /* Odnoklassniki.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A351C95139A00534083 /* Odnoklassniki.plist */; };
-		0BF06A9C1C95139A00534083 /* Odnoklassniki.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A351C95139A00534083 /* Odnoklassniki.plist */; };
-		0BF06A9D1C95139A00534083 /* Overcast.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A361C95139A00534083 /* Overcast.plist */; };
-		0BF06A9E1C95139A00534083 /* Overcast.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A361C95139A00534083 /* Overcast.plist */; };
-		0BF06A9F1C95139A00534083 /* Pandora.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A371C95139A00534083 /* Pandora.plist */; };
-		0BF06AA01C95139A00534083 /* Pandora.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A371C95139A00534083 /* Pandora.plist */; };
-		0BF06AA11C95139A00534083 /* PlexWeb.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A381C95139A00534083 /* PlexWeb.plist */; };
-		0BF06AA21C95139A00534083 /* PlexWeb.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A381C95139A00534083 /* PlexWeb.plist */; };
-		0BF06AA31C95139A00534083 /* PocketCasts.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A391C95139A00534083 /* PocketCasts.plist */; };
-		0BF06AA41C95139A00534083 /* PocketCasts.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A391C95139A00534083 /* PocketCasts.plist */; };
-		0BF06AA51C95139A00534083 /* Rdio.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A3A1C95139A00534083 /* Rdio.plist */; };
-		0BF06AA61C95139A00534083 /* Rdio.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A3A1C95139A00534083 /* Rdio.plist */; };
-		0BF06AA71C95139A00534083 /* Rhapsody.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A3B1C95139A00534083 /* Rhapsody.plist */; };
-		0BF06AA81C95139A00534083 /* Rhapsody.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A3B1C95139A00534083 /* Rhapsody.plist */; };
-		0BF06AA91C95139A00534083 /* Saavn.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A3C1C95139A00534083 /* Saavn.plist */; };
-		0BF06AAA1C95139A00534083 /* Saavn.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A3C1C95139A00534083 /* Saavn.plist */; };
-		0BF06AAB1C95139A00534083 /* ShufflerFm.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A3D1C95139A00534083 /* ShufflerFm.plist */; };
-		0BF06AAC1C95139A00534083 /* ShufflerFm.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A3D1C95139A00534083 /* ShufflerFm.plist */; };
-		0BF06AAD1C95139A00534083 /* Slacker.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A3E1C95139A00534083 /* Slacker.plist */; };
-		0BF06AAE1C95139A00534083 /* Slacker.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A3E1C95139A00534083 /* Slacker.plist */; };
-		0BF06AAF1C95139A00534083 /* SomaFm.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A3F1C95139A00534083 /* SomaFm.plist */; };
-		0BF06AB01C95139A00534083 /* SomaFm.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A3F1C95139A00534083 /* SomaFm.plist */; };
-		0BF06AB11C95139A00534083 /* Songza.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A401C95139A00534083 /* Songza.plist */; };
-		0BF06AB21C95139A00534083 /* Songza.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A401C95139A00534083 /* Songza.plist */; };
-		0BF06AB31C95139A00534083 /* SoundCloud.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A411C95139A00534083 /* SoundCloud.plist */; };
-		0BF06AB41C95139A00534083 /* SoundCloud.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A411C95139A00534083 /* SoundCloud.plist */; };
-		0BF06AB51C95139A00534083 /* Spotify.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A421C95139A00534083 /* Spotify.plist */; };
-		0BF06AB61C95139A00534083 /* Spotify.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A421C95139A00534083 /* Spotify.plist */; };
-		0BF06AB71C95139A00534083 /* Stitcher.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A431C95139A00534083 /* Stitcher.plist */; };
-		0BF06AB81C95139A00534083 /* Stitcher.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A431C95139A00534083 /* Stitcher.plist */; };
-		0BF06AB91C95139A00534083 /* Subsonic.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A441C95139A00534083 /* Subsonic.plist */; };
-		0BF06ABA1C95139A00534083 /* Subsonic.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A441C95139A00534083 /* Subsonic.plist */; };
-		0BF06ABB1C95139A00534083 /* Synology.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A451C95139A00534083 /* Synology.plist */; };
-		0BF06ABC1C95139A00534083 /* Synology.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A451C95139A00534083 /* Synology.plist */; };
-		0BF06ABD1C95139A00534083 /* TidalHiFi.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A461C95139A00534083 /* TidalHiFi.plist */; };
-		0BF06ABE1C95139A00534083 /* TidalHiFi.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A461C95139A00534083 /* TidalHiFi.plist */; };
-		0BF06ABF1C95139A00534083 /* TuneIn.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A471C95139A00534083 /* TuneIn.plist */; };
-		0BF06AC01C95139A00534083 /* TuneIn.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A471C95139A00534083 /* TuneIn.plist */; };
-		0BF06AC11C95139A00534083 /* TwentyTwoTracks.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A481C95139A00534083 /* TwentyTwoTracks.plist */; };
-		0BF06AC21C95139A00534083 /* TwentyTwoTracks.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A481C95139A00534083 /* TwentyTwoTracks.plist */; };
-		0BF06AC31C95139A00534083 /* Twitch.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A491C95139A00534083 /* Twitch.plist */; };
-		0BF06AC41C95139A00534083 /* Twitch.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A491C95139A00534083 /* Twitch.plist */; };
-		0BF06AC51C95139A00534083 /* Udemy.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A4A1C95139A00534083 /* Udemy.plist */; };
-		0BF06AC61C95139A00534083 /* Udemy.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A4A1C95139A00534083 /* Udemy.plist */; };
-		0BF06AC71C95139A00534083 /* versions.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A4B1C95139A00534083 /* versions.plist */; };
-		0BF06AC81C95139A00534083 /* versions.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A4B1C95139A00534083 /* versions.plist */; };
-		0BF06AC91C95139A00534083 /* Vessel.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A4C1C95139A00534083 /* Vessel.plist */; };
-		0BF06ACA1C95139A00534083 /* Vessel.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A4C1C95139A00534083 /* Vessel.plist */; };
-		0BF06ACB1C95139A00534083 /* Vimeo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A4D1C95139A00534083 /* Vimeo.plist */; };
-		0BF06ACC1C95139A00534083 /* Vimeo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A4D1C95139A00534083 /* Vimeo.plist */; };
-		0BF06ACD1C95139A00534083 /* Vk.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A4E1C95139A00534083 /* Vk.plist */; };
-		0BF06ACE1C95139A00534083 /* Vk.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A4E1C95139A00534083 /* Vk.plist */; };
-		0BF06ACF1C95139A00534083 /* WatchaPlay.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A4F1C95139A00534083 /* WatchaPlay.plist */; };
-		0BF06AD01C95139A00534083 /* WatchaPlay.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A4F1C95139A00534083 /* WatchaPlay.plist */; };
-		0BF06AD11C95139A00534083 /* WonderFm.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A501C95139A00534083 /* WonderFm.plist */; };
-		0BF06AD21C95139A00534083 /* WonderFm.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A501C95139A00534083 /* WonderFm.plist */; };
-		0BF06AD31C95139A00534083 /* XboxMusic.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A511C95139A00534083 /* XboxMusic.plist */; };
-		0BF06AD41C95139A00534083 /* XboxMusic.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A511C95139A00534083 /* XboxMusic.plist */; };
-		0BF06AD51C95139A00534083 /* YandexMusic.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A521C95139A00534083 /* YandexMusic.plist */; };
-		0BF06AD61C95139A00534083 /* YandexMusic.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A521C95139A00534083 /* YandexMusic.plist */; };
-		0BF06AD71C95139A00534083 /* YandexRadio.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A531C95139A00534083 /* YandexRadio.plist */; };
-		0BF06AD81C95139A00534083 /* YandexRadio.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A531C95139A00534083 /* YandexRadio.plist */; };
-		0BF06AD91C95139A00534083 /* Youtube.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A541C95139A00534083 /* Youtube.plist */; };
-		0BF06ADA1C95139A00534083 /* Youtube.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BF06A541C95139A00534083 /* Youtube.plist */; };
+		0BD1B2F31CD21AA900B72A3E /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0BD1B2F21CD21AA900B72A3E /* JavaScriptCore.framework */; };
+		0BD1B2F41CD21AB100B72A3E /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0BD1B2F21CD21AA900B72A3E /* JavaScriptCore.framework */; };
+		0BE800771CDA4F5B001A4DDF /* versions.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BE8FFFA1CDA4F5B001A4DDF /* versions.plist */; };
+		0BE800781CDA4F5B001A4DDF /* versions.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0BE8FFFA1CDA4F5B001A4DDF /* versions.plist */; };
 		0BF06AE11C9513A800534083 /* BSMediaStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BF06ADC1C9513A800534083 /* BSMediaStrategy.m */; };
 		0BF06AE31C9513A800534083 /* BSStrategyVersionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BF06ADE1C9513A800534083 /* BSStrategyVersionManager.m */; };
 		0BF06AE51C9513A800534083 /* BSTrack.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BF06AE01C9513A800534083 /* BSTrack.m */; };
-		17C5B63A18DB33C0006F38C1 /* beard@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 17C5B63918DB33C0006F38C1 /* beard@2x.png */; };
-		17C5B63C18DB3649006F38C1 /* beard-highlighted@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 17C5B63B18DB3649006F38C1 /* beard-highlighted@2x.png */; };
-		1E1426F8950EBED0E2020816 /* libPods-BeardedSpiceControllers.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F20B81547A29635C2DF0434 /* libPods-BeardedSpiceControllers.a */; };
-		5ECFDCD81CD8F8DE00811169 /* DowncastTabAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ECFDCD71CD8F8DE00811169 /* DowncastTabAdapter.m */; };
+		0BF9CAE71CFFDB2F00E9986B /* NSString+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 656A002C1C8AD41A00BD29F5 /* NSString+Utils.m */; };
+		11A36C1600CD983E3627C87A /* libPods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 53666B3CA02A56F052042196 /* libPods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.a */; };
+		57EC5B34F4AD4F87F5D44625 /* libPods-BeardedSpiceControllers.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7FAD2F3C92017C9093D70503 /* libPods-BeardedSpiceControllers.a */; };
+		5E80769F1D58CE180002855D /* DowncastTabAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E80769E1D58CE180002855D /* DowncastTabAdapter.m */; };
 		651967C21AB3A0B200B48D3A /* iTunesTabAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 651967C11AB3A0B200B48D3A /* iTunesTabAdapter.m */; };
 		6537DAA81AF396DA002F2391 /* NativeAppTabRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 6537DAA71AF396DA002F2391 /* NativeAppTabRegistry.m */; };
 		6537DAAB1AF508DF002F2391 /* MediaControllerObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 6537DAAA1AF508DF002F2391 /* MediaControllerObject.m */; };
 		6537DAAD1AF6E666002F2391 /* SpotifyTabAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 65C511691AED66A700EBA6A5 /* SpotifyTabAdapter.m */; };
 		653BCAD21AB25DAC0034D27F /* ShortcutsPreferencesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 653BCAD01AB25DAC0034D27F /* ShortcutsPreferencesViewController.m */; };
+		655AACA91D3ABFAA00E316EA /* EHCCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 655AACA61D3ABFAA00E316EA /* EHCCache.m */; };
+		655AACAA1D3ABFAA00E316EA /* NSArray+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 655AACA81D3ABFAA00E316EA /* NSArray+Utils.m */; };
 		656A00131C8AD3C800BD29F5 /* DDHidAppleMikey.m in Sources */ = {isa = PBXBuildFile; fileRef = 656A00001C8AD3C800BD29F5 /* DDHidAppleMikey.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		656A00141C8AD3C800BD29F5 /* DDHidAppleRemote.m in Sources */ = {isa = PBXBuildFile; fileRef = 656A00021C8AD3C800BD29F5 /* DDHidAppleRemote.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		656A00151C8AD3C800BD29F5 /* DDHidDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = 656A00041C8AD3C800BD29F5 /* DDHidDevice.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
@@ -180,7 +56,6 @@
 		656A00331C8AD41A00BD29F5 /* NSException+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 656A002A1C8AD41A00BD29F5 /* NSException+Utils.m */; };
 		656A00341C8AD41A00BD29F5 /* NSException+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 656A002A1C8AD41A00BD29F5 /* NSException+Utils.m */; };
 		656A00351C8AD41A00BD29F5 /* NSString+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 656A002C1C8AD41A00BD29F5 /* NSString+Utils.m */; };
-		656A00361C8AD41A00BD29F5 /* NSString+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 656A002C1C8AD41A00BD29F5 /* NSString+Utils.m */; };
 		656A00371C8AD41A00BD29F5 /* NSURL+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 656A002E1C8AD41A00BD29F5 /* NSURL+Utils.m */; };
 		656A00381C8AD41A00BD29F5 /* NSURL+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 656A002E1C8AD41A00BD29F5 /* NSURL+Utils.m */; };
 		656A003D1C8B01BC00BD29F5 /* BSSharedDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = 656A003C1C8B01BC00BD29F5 /* BSSharedDefaults.m */; };
@@ -195,14 +70,21 @@
 		65A850191C8DE9D900D54C77 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03F33ECB1855306A00E8F77E /* Carbon.framework */; };
 		65A8501A1C8DE9E000D54C77 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65E567071B76104300AD2D46 /* CoreAudio.framework */; };
 		65A8501D1C9330F800D54C77 /* BSCShortcutMonitor.m in Sources */ = {isa = PBXBuildFile; fileRef = 65A8501C1C9330F800D54C77 /* BSCShortcutMonitor.m */; };
+		65ABBAA61D1EC7D000F882CE /* BSCustomStrategyManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 65ABBAA51D1EC7D000F882CE /* BSCustomStrategyManager.m */; };
+		65ADE6051D169D0C000C29F1 /* EHVerticalCenteredTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = 65ADE6041D169D0C000C29F1 /* EHVerticalCenteredTextField.m */; };
 		65B32B8E1AD99D1600F696B9 /* TabAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B32B8D1AD99D1600F696B9 /* TabAdapter.m */; };
 		65C511721AED802B00EBA6A5 /* NativeAppTabAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 65C511711AED802B00EBA6A5 /* NativeAppTabAdapter.m */; };
+		65D57FCB1D02CBFE0016F270 /* MediaStrategies in Resources */ = {isa = PBXBuildFile; fileRef = 65D57FCA1D02CBFE0016F270 /* MediaStrategies */; };
+		65D57FCC1D02CC250016F270 /* MediaStrategies in Resources */ = {isa = PBXBuildFile; fileRef = 65D57FCA1D02CBFE0016F270 /* MediaStrategies */; };
+		65D57FCD1D02CCB00016F270 /* NSURL+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 656A002E1C8AD41A00BD29F5 /* NSURL+Utils.m */; };
+		65D57FCE1D02CD140016F270 /* BSMediaStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BF06ADC1C9513A800534083 /* BSMediaStrategy.m */; };
 		65E5670E1B76A07700AD2D46 /* BSMediaStrategyEnableButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 65E5670D1B76A07700AD2D46 /* BSMediaStrategyEnableButton.m */; };
 		65E567111B76AE3A00AD2D46 /* BSPreferencesWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 65E567101B76AE3A00AD2D46 /* BSPreferencesWindowController.m */; };
 		65E567141B775C9300AD2D46 /* BSShortcutView.m in Sources */ = {isa = PBXBuildFile; fileRef = 65E567131B775C9300AD2D46 /* BSShortcutView.m */; };
 		65EE289E1AB6003800EFC886 /* GeneralPreferencesView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 65EE28A01AB6003800EFC886 /* GeneralPreferencesView.xib */; };
 		65EE28A11AB6003B00EFC886 /* ShortcutsPreferencesView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 65EE28A31AB6003B00EFC886 /* ShortcutsPreferencesView.xib */; };
 		65FF756C1B36CEDF00D81CA5 /* BSLaunchAtLogin.m in Sources */ = {isa = PBXBuildFile; fileRef = 65FF756B1B36CEDF00D81CA5 /* BSLaunchAtLogin.m */; };
+		7D8A002D0E49A89BB9CB53DD /* libPods-BeardedSpiceControllers-BeardedSpice.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A13F7ACE82D7C5DF91641532 /* libPods-BeardedSpiceControllers-BeardedSpice.a */; };
 		967933301855173100A49AC7 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9679332F1855173100A49AC7 /* Cocoa.framework */; };
 		9679333C1855173100A49AC7 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 9679333B1855173100A49AC7 /* main.m */; };
 		967933431855173100A49AC7 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 967933421855173100A49AC7 /* AppDelegate.m */; };
@@ -210,11 +92,8 @@
 		967933481855173100A49AC7 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 967933471855173100A49AC7 /* Images.xcassets */; };
 		9679334F1855173100A49AC7 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9679334E1855173100A49AC7 /* XCTest.framework */; };
 		967933501855173100A49AC7 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9679332F1855173100A49AC7 /* Cocoa.framework */; };
-		9679335A1855173100A49AC7 /* BeardedSpiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 967933591855173100A49AC7 /* BeardedSpiceTests.m */; };
 		9679336518551BCC00A49AC7 /* ScriptingBridge.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9679336418551BCC00A49AC7 /* ScriptingBridge.framework */; };
-		C7EBE1D19BB5376934A3F6D3 /* libPods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 45EC506CE39EEDB80F99EA07 /* libPods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.a */; };
 		D09EFF221C8CD49E00B24DA9 /* VLCTabAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = D09EFF1F1C8CD49E00B24DA9 /* VLCTabAdapter.m */; };
-		DAD858605B37FF09D3AAD082 /* libPods-BeardedSpiceControllers-BeardedSpice.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 28CA978C46A156EA9D1CFA4A /* libPods-BeardedSpiceControllers-BeardedSpice.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -260,10 +139,8 @@
 
 /* Begin PBXFileReference section */
 		030123391868B1F90080115F /* BeardedSpiceUserDefaults.plist */ = {isa = PBXFileReference; lastKnownFileType = file.bplist; path = BeardedSpiceUserDefaults.plist; sourceTree = "<group>"; };
-		0320C0511868C6C2009591CA /* beard.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = beard.png; sourceTree = "<group>"; };
-		0320C0531868C7A4009591CA /* beard-highlighted.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "beard-highlighted.png"; sourceTree = "<group>"; };
 		0369231C1862936600E04DDB /* GeneralPreferencesViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GeneralPreferencesViewController.h; sourceTree = "<group>"; };
-		0369231D1862936600E04DDB /* GeneralPreferencesViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneralPreferencesViewController.m; sourceTree = "<group>"; };
+		0369231D1862936600E04DDB /* GeneralPreferencesViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = GeneralPreferencesViewController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		03A34920185EA43900C4A62B /* MediaStrategyRegistry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = MediaStrategyRegistry.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		03A34921185EA43900C4A62B /* MediaStrategyRegistry.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = MediaStrategyRegistry.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		03F33ECB1855306A00E8F77E /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
@@ -272,101 +149,47 @@
 		03F33EEC1857E3C000E8F77E /* ChromeTabAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = ChromeTabAdapter.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		03F33EEE1857E59B00E8F77E /* SafariTabAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = SafariTabAdapter.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		03F33EEF1857E59B00E8F77E /* SafariTabAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = SafariTabAdapter.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		0BF06A121C95139900534083 /* AmazonMusic.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = AmazonMusic.plist; sourceTree = "<group>"; };
-		0BF06A131C95139900534083 /* Audible.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Audible.plist; sourceTree = "<group>"; };
-		0BF06A141C95139900534083 /* AudioMack.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = AudioMack.plist; sourceTree = "<group>"; };
-		0BF06A151C95139900534083 /* BandCamp.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = BandCamp.plist; sourceTree = "<group>"; };
-		0BF06A161C95139900534083 /* BBCRadio.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = BBCRadio.plist; sourceTree = "<group>"; };
-		0BF06A171C95139900534083 /* Beatguide.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Beatguide.plist; sourceTree = "<group>"; };
-		0BF06A181C95139900534083 /* BeatsMusic.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = BeatsMusic.plist; sourceTree = "<group>"; };
-		0BF06A191C95139900534083 /* Blitzr.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Blitzr.plist; sourceTree = "<group>"; };
-		0BF06A1A1C95139900534083 /* BrainFm.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = BrainFm.plist; sourceTree = "<group>"; };
-		0BF06A1B1C95139900534083 /* BugsMusic.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = BugsMusic.plist; sourceTree = "<group>"; };
-		0BF06A1C1C95139900534083 /* Chorus.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Chorus.plist; sourceTree = "<group>"; };
-		0BF06A1D1C95139900534083 /* Composed.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Composed.plist; sourceTree = "<group>"; };
-		0BF06A1E1C95139900534083 /* Coursera.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Coursera.plist; sourceTree = "<group>"; };
-		0BF06A1F1C95139900534083 /* Deezer.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Deezer.plist; sourceTree = "<group>"; };
-		0BF06A201C95139900534083 /* DigitallyImported.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = DigitallyImported.plist; sourceTree = "<group>"; };
-		0BF06A211C95139900534083 /* EightTracks.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = EightTracks.plist; sourceTree = "<group>"; };
-		0BF06A221C95139900534083 /* FocusAtWill.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = FocusAtWill.plist; sourceTree = "<group>"; };
-		0BF06A231C95139900534083 /* GoogleMusic.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = GoogleMusic.plist; sourceTree = "<group>"; };
-		0BF06A241C95139900534083 /* GrooveShark.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = GrooveShark.plist; sourceTree = "<group>"; };
-		0BF06A251C95139900534083 /* HotNewHipHop.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = HotNewHipHop.plist; sourceTree = "<group>"; };
-		0BF06A261C95139900534083 /* HypeMachine.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = HypeMachine.plist; sourceTree = "<group>"; };
-		0BF06A271C95139A00534083 /* iHeartRadio.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = iHeartRadio.plist; sourceTree = "<group>"; };
-		0BF06A281C95139A00534083 /* IndieShuffle.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = IndieShuffle.plist; sourceTree = "<group>"; };
-		0BF06A291C95139A00534083 /* Jango.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Jango.plist; sourceTree = "<group>"; };
-		0BF06A2A1C95139A00534083 /* KollektFm.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = KollektFm.plist; sourceTree = "<group>"; };
-		0BF06A2B1C95139A00534083 /* LastFm.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = LastFm.plist; sourceTree = "<group>"; };
-		0BF06A2C1C95139A00534083 /* LeTournedisque.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = LeTournedisque.plist; sourceTree = "<group>"; };
-		0BF06A2D1C95139A00534083 /* LogitechMediaServer.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = LogitechMediaServer.plist; sourceTree = "<group>"; };
-		0BF06A2E1C95139A00534083 /* MixCloud.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = MixCloud.plist; sourceTree = "<group>"; };
-		0BF06A2F1C95139A00534083 /* MusicForProgramming.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = MusicForProgramming.plist; sourceTree = "<group>"; };
-		0BF06A301C95139A00534083 /* MusicUnlimited.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = MusicUnlimited.plist; sourceTree = "<group>"; };
-		0BF06A311C95139A00534083 /* Netflix.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Netflix.plist; sourceTree = "<group>"; };
-		0BF06A321C95139A00534083 /* NoAdRadio.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = NoAdRadio.plist; sourceTree = "<group>"; };
-		0BF06A331C95139A00534083 /* NoonPacific.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = NoonPacific.plist; sourceTree = "<group>"; };
-		0BF06A341C95139A00534083 /* NRK.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = NRK.plist; sourceTree = "<group>"; };
-		0BF06A351C95139A00534083 /* Odnoklassniki.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Odnoklassniki.plist; sourceTree = "<group>"; };
-		0BF06A361C95139A00534083 /* Overcast.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Overcast.plist; sourceTree = "<group>"; };
-		0BF06A371C95139A00534083 /* Pandora.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Pandora.plist; sourceTree = "<group>"; };
-		0BF06A381C95139A00534083 /* PlexWeb.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = PlexWeb.plist; sourceTree = "<group>"; };
-		0BF06A391C95139A00534083 /* PocketCasts.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = PocketCasts.plist; sourceTree = "<group>"; };
-		0BF06A3A1C95139A00534083 /* Rdio.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Rdio.plist; sourceTree = "<group>"; };
-		0BF06A3B1C95139A00534083 /* Rhapsody.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Rhapsody.plist; sourceTree = "<group>"; };
-		0BF06A3C1C95139A00534083 /* Saavn.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Saavn.plist; sourceTree = "<group>"; };
-		0BF06A3D1C95139A00534083 /* ShufflerFm.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = ShufflerFm.plist; sourceTree = "<group>"; };
-		0BF06A3E1C95139A00534083 /* Slacker.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Slacker.plist; sourceTree = "<group>"; };
-		0BF06A3F1C95139A00534083 /* SomaFm.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = SomaFm.plist; sourceTree = "<group>"; };
-		0BF06A401C95139A00534083 /* Songza.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Songza.plist; sourceTree = "<group>"; };
-		0BF06A411C95139A00534083 /* SoundCloud.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = SoundCloud.plist; sourceTree = "<group>"; };
-		0BF06A421C95139A00534083 /* Spotify.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Spotify.plist; sourceTree = "<group>"; };
-		0BF06A431C95139A00534083 /* Stitcher.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Stitcher.plist; sourceTree = "<group>"; };
-		0BF06A441C95139A00534083 /* Subsonic.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Subsonic.plist; sourceTree = "<group>"; };
-		0BF06A451C95139A00534083 /* Synology.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Synology.plist; sourceTree = "<group>"; };
-		0BF06A461C95139A00534083 /* TidalHiFi.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = TidalHiFi.plist; sourceTree = "<group>"; };
-		0BF06A471C95139A00534083 /* TuneIn.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = TuneIn.plist; sourceTree = "<group>"; };
-		0BF06A481C95139A00534083 /* TwentyTwoTracks.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = TwentyTwoTracks.plist; sourceTree = "<group>"; };
-		0BF06A491C95139A00534083 /* Twitch.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Twitch.plist; sourceTree = "<group>"; };
-		0BF06A4A1C95139A00534083 /* Udemy.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Udemy.plist; sourceTree = "<group>"; };
-		0BF06A4B1C95139A00534083 /* versions.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = versions.plist; sourceTree = "<group>"; };
-		0BF06A4C1C95139A00534083 /* Vessel.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Vessel.plist; sourceTree = "<group>"; };
-		0BF06A4D1C95139A00534083 /* Vimeo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Vimeo.plist; sourceTree = "<group>"; };
-		0BF06A4E1C95139A00534083 /* Vk.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Vk.plist; sourceTree = "<group>"; };
-		0BF06A4F1C95139A00534083 /* WatchaPlay.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = WatchaPlay.plist; sourceTree = "<group>"; };
-		0BF06A501C95139A00534083 /* WonderFm.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = WonderFm.plist; sourceTree = "<group>"; };
-		0BF06A511C95139A00534083 /* XboxMusic.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = XboxMusic.plist; sourceTree = "<group>"; };
-		0BF06A521C95139A00534083 /* YandexMusic.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = YandexMusic.plist; sourceTree = "<group>"; };
-		0BF06A531C95139A00534083 /* YandexRadio.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = YandexRadio.plist; sourceTree = "<group>"; };
-		0BF06A541C95139A00534083 /* Youtube.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Youtube.plist; sourceTree = "<group>"; };
+		0B1AF3761CCE4D4C0021BBEA /* BSMediaStrategyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSMediaStrategyTests.m; sourceTree = "<group>"; };
+		0B1AF3771CCE4D4C0021BBEA /* BSStrategyMockObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSStrategyMockObject.h; sourceTree = "<group>"; };
+		0B1AF3781CCE4D4C0021BBEA /* BSStrategyMockObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSStrategyMockObject.m; sourceTree = "<group>"; };
+		0B1AF3791CCE4D4C0021BBEA /* BSStrategyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSStrategyTests.m; sourceTree = "<group>"; };
+		0B1AF37C1CCE4D4C0021BBEA /* BSTrackTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSTrackTests.m; sourceTree = "<group>"; };
+		0B33014C1CFA643F0090DB67 /* BSStrategyCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSStrategyCache.h; sourceTree = "<group>"; };
+		0B33014D1CFA643F0090DB67 /* BSStrategyCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSStrategyCache.m; sourceTree = "<group>"; };
+		0BD1B2F21CD21AA900B72A3E /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		0BE8FFFA1CDA4F5B001A4DDF /* versions.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = versions.plist; path = MediaStrategies/versions.plist; sourceTree = "<group>"; };
 		0BF06ADB1C9513A800534083 /* BSMediaStrategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSMediaStrategy.h; sourceTree = "<group>"; };
 		0BF06ADC1C9513A800534083 /* BSMediaStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSMediaStrategy.m; sourceTree = "<group>"; };
-		0BF06ADD1C9513A800534083 /* BSStrategyVersionManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSStrategyVersionManager.h; sourceTree = "<group>"; };
-		0BF06ADE1C9513A800534083 /* BSStrategyVersionManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSStrategyVersionManager.m; sourceTree = "<group>"; };
+		0BF06ADD1C9513A800534083 /* BSStrategyVersionManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = BSStrategyVersionManager.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
+		0BF06ADE1C9513A800534083 /* BSStrategyVersionManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = BSStrategyVersionManager.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		0BF06ADF1C9513A800534083 /* BSTrack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSTrack.h; sourceTree = "<group>"; };
 		0BF06AE01C9513A800534083 /* BSTrack.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSTrack.m; sourceTree = "<group>"; };
-		17C5B63918DB33C0006F38C1 /* beard@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "beard@2x.png"; sourceTree = "<group>"; };
-		17C5B63B18DB3649006F38C1 /* beard-highlighted@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "beard-highlighted@2x.png"; sourceTree = "<group>"; };
-		2299BC537DEC481A9540F7CA /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		28CA978C46A156EA9D1CFA4A /* libPods-BeardedSpiceControllers-BeardedSpice.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BeardedSpiceControllers-BeardedSpice.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		2F6D87D0EA72A7C89F896C4E /* Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests/Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.debug.xcconfig"; sourceTree = "<group>"; };
-		45EC506CE39EEDB80F99EA07 /* libPods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		5ECFDCD51CD8F8DE00811169 /* Downcast.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Downcast.h; sourceTree = "<group>"; };
-		5ECFDCD61CD8F8DE00811169 /* DowncastTabAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DowncastTabAdapter.h; sourceTree = "<group>"; };
-		5ECFDCD71CD8F8DE00811169 /* DowncastTabAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DowncastTabAdapter.m; sourceTree = "<group>"; };
+		19F70640AA530B57CAE19126 /* Pods-BeardedSpiceControllers.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeardedSpiceControllers.release.xcconfig"; path = "Pods/Target Support Files/Pods-BeardedSpiceControllers/Pods-BeardedSpiceControllers.release.xcconfig"; sourceTree = "<group>"; };
+		2276A4EDC9C2D1AAD937291D /* Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests/Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.debug.xcconfig"; sourceTree = "<group>"; };
+		2A913DB70FE33880FAD92004 /* Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests/Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.release.xcconfig"; sourceTree = "<group>"; };
+		412BD1821FB849B7F1BABF75 /* Pods-BeardedSpiceControllers-BeardedSpice.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeardedSpiceControllers-BeardedSpice.release.xcconfig"; path = "Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice/Pods-BeardedSpiceControllers-BeardedSpice.release.xcconfig"; sourceTree = "<group>"; };
+		47E7DF3674629C3865366CA8 /* Pods-BeardedSpiceControllers-BeardedSpice.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeardedSpiceControllers-BeardedSpice.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice/Pods-BeardedSpiceControllers-BeardedSpice.debug.xcconfig"; sourceTree = "<group>"; };
+		53666B3CA02A56F052042196 /* libPods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5E80769C1D58CE180002855D /* Downcast.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Downcast.h; sourceTree = "<group>"; };
+		5E80769D1D58CE180002855D /* DowncastTabAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DowncastTabAdapter.h; sourceTree = "<group>"; };
+		5E80769E1D58CE180002855D /* DowncastTabAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DowncastTabAdapter.m; sourceTree = "<group>"; };
 		651967BF1AB3858800B48D3A /* iTunes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = iTunes.h; sourceTree = "<group>"; };
 		651967C01AB3A0B200B48D3A /* iTunesTabAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = iTunesTabAdapter.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		651967C11AB3A0B200B48D3A /* iTunesTabAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = iTunesTabAdapter.m; sourceTree = "<group>"; };
 		652AD3361CC04A7C005396CD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/GeneralPreferencesView.xib; sourceTree = "<group>"; };
 		652AD3371CC04A7C005396CD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/ShortcutsPreferencesView.xib; sourceTree = "<group>"; };
 		652AD3381CC04A7D005396CD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
-		652AD3391CC04ABA005396CD /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
+		652AD3391CC04ABA005396CD /* Base */ = {isa = PBXFileReference; fileEncoding = 10; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6537DAA61AF396DA002F2391 /* NativeAppTabRegistry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NativeAppTabRegistry.h; sourceTree = "<group>"; };
 		6537DAA71AF396DA002F2391 /* NativeAppTabRegistry.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NativeAppTabRegistry.m; sourceTree = "<group>"; };
 		6537DAA91AF508DF002F2391 /* MediaControllerObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MediaControllerObject.h; sourceTree = "<group>"; };
 		6537DAAA1AF508DF002F2391 /* MediaControllerObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MediaControllerObject.m; sourceTree = "<group>"; };
 		653BCACF1AB25DAC0034D27F /* ShortcutsPreferencesViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShortcutsPreferencesViewController.h; sourceTree = "<group>"; };
 		653BCAD01AB25DAC0034D27F /* ShortcutsPreferencesViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ShortcutsPreferencesViewController.m; sourceTree = "<group>"; };
+		655AACA51D3ABFAA00E316EA /* EHCCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EHCCache.h; sourceTree = "<group>"; };
+		655AACA61D3ABFAA00E316EA /* EHCCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EHCCache.m; sourceTree = "<group>"; };
+		655AACA71D3ABFAA00E316EA /* NSArray+Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+Utils.h"; sourceTree = "<group>"; };
+		655AACA81D3ABFAA00E316EA /* NSArray+Utils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSArray+Utils.m"; sourceTree = "<group>"; };
 		656A00001C8AD3C800BD29F5 /* DDHidAppleMikey.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDHidAppleMikey.m; sourceTree = "<group>"; };
 		656A00011C8AD3C800BD29F5 /* DDHidAppleRemote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDHidAppleRemote.h; sourceTree = "<group>"; };
 		656A00021C8AD3C800BD29F5 /* DDHidAppleRemote.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDHidAppleRemote.m; sourceTree = "<group>"; };
@@ -421,6 +244,11 @@
 		65A850151C8B065000D54C77 /* BSCService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = BSCService.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		65A8501B1C9330F800D54C77 /* BSCShortcutMonitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = BSCShortcutMonitor.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		65A8501C1C9330F800D54C77 /* BSCShortcutMonitor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = BSCShortcutMonitor.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		65ABBAA41D1EC7D000F882CE /* BSCustomStrategyManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSCustomStrategyManager.h; sourceTree = "<group>"; };
+		65ABBAA51D1EC7D000F882CE /* BSCustomStrategyManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSCustomStrategyManager.m; sourceTree = "<group>"; };
+		65ABBAA81D1FDC5400F882CE /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		65ADE6031D169D0C000C29F1 /* EHVerticalCenteredTextField.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EHVerticalCenteredTextField.h; sourceTree = "<group>"; };
+		65ADE6041D169D0C000C29F1 /* EHVerticalCenteredTextField.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EHVerticalCenteredTextField.m; sourceTree = "<group>"; };
 		65B32B8C1AD99D1600F696B9 /* TabAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TabAdapter.h; sourceTree = "<group>"; };
 		65B32B8D1AD99D1600F696B9 /* TabAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TabAdapter.m; sourceTree = "<group>"; };
 		65C511691AED66A700EBA6A5 /* SpotifyTabAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SpotifyTabAdapter.m; sourceTree = "<group>"; };
@@ -428,6 +256,8 @@
 		65C5116C1AED688800EBA6A5 /* Spotify.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Spotify.h; sourceTree = "<group>"; };
 		65C511701AED802B00EBA6A5 /* NativeAppTabAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NativeAppTabAdapter.h; sourceTree = "<group>"; };
 		65C511711AED802B00EBA6A5 /* NativeAppTabAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NativeAppTabAdapter.m; sourceTree = "<group>"; };
+		65D57FCA1D02CBFE0016F270 /* MediaStrategies */ = {isa = PBXFileReference; lastKnownFileType = folder; path = MediaStrategies; sourceTree = "<group>"; };
+		65D57FCF1D02E64F0016F270 /* Debug-Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Debug-Config.xcconfig"; sourceTree = "<group>"; };
 		65E567071B76104300AD2D46 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
 		65E5670C1B76A07700AD2D46 /* BSMediaStrategyEnableButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSMediaStrategyEnableButton.h; sourceTree = "<group>"; };
 		65E5670D1B76A07700AD2D46 /* BSMediaStrategyEnableButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSMediaStrategyEnableButton.m; sourceTree = "<group>"; };
@@ -437,8 +267,8 @@
 		65E567131B775C9300AD2D46 /* BSShortcutView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSShortcutView.m; sourceTree = "<group>"; };
 		65FF756A1B36CEDF00D81CA5 /* BSLaunchAtLogin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSLaunchAtLogin.h; sourceTree = "<group>"; };
 		65FF756B1B36CEDF00D81CA5 /* BSLaunchAtLogin.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSLaunchAtLogin.m; sourceTree = "<group>"; };
-		7A9EAC832D8E08D9DFB67396 /* Pods-BeardedSpiceControllers.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeardedSpiceControllers.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BeardedSpiceControllers/Pods-BeardedSpiceControllers.debug.xcconfig"; sourceTree = "<group>"; };
-		7F20B81547A29635C2DF0434 /* libPods-BeardedSpiceControllers.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BeardedSpiceControllers.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7FAD2F3C92017C9093D70503 /* libPods-BeardedSpiceControllers.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BeardedSpiceControllers.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		91351FB7426B1A29959CEE4B /* Pods-BeardedSpiceControllers.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeardedSpiceControllers.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BeardedSpiceControllers/Pods-BeardedSpiceControllers.debug.xcconfig"; sourceTree = "<group>"; };
 		9679332C1855173100A49AC7 /* BeardedSpice.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BeardedSpice.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9679332F1855173100A49AC7 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		967933321855173100A49AC7 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
@@ -453,16 +283,12 @@
 		9679334D1855173100A49AC7 /* BeardedSpiceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BeardedSpiceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9679334E1855173100A49AC7 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		967933551855173100A49AC7 /* BeardedSpiceTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "BeardedSpiceTests-Info.plist"; sourceTree = "<group>"; };
-		967933591855173100A49AC7 /* BeardedSpiceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = BeardedSpiceTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		9679336318551A8F00A49AC7 /* Chrome.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Chrome.h; sourceTree = "<group>"; };
 		9679336418551BCC00A49AC7 /* ScriptingBridge.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ScriptingBridge.framework; path = System/Library/Frameworks/ScriptingBridge.framework; sourceTree = SDKROOT; };
-		968406BFD21574C07B747F37 /* Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests/Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.release.xcconfig"; sourceTree = "<group>"; };
-		9F9355D0AD84C962E403B8AB /* Pods-BeardedSpiceControllers.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeardedSpiceControllers.release.xcconfig"; path = "Pods/Target Support Files/Pods-BeardedSpiceControllers/Pods-BeardedSpiceControllers.release.xcconfig"; sourceTree = "<group>"; };
-		CBC84E9024D0B34C3324D861 /* Pods-BeardedSpiceControllers-BeardedSpice.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeardedSpiceControllers-BeardedSpice.release.xcconfig"; path = "Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice/Pods-BeardedSpiceControllers-BeardedSpice.release.xcconfig"; sourceTree = "<group>"; };
+		A13F7ACE82D7C5DF91641532 /* libPods-BeardedSpiceControllers-BeardedSpice.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BeardedSpiceControllers-BeardedSpice.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D09EFF1F1C8CD49E00B24DA9 /* VLCTabAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VLCTabAdapter.m; sourceTree = "<group>"; };
 		D09EFF201C8CD49E00B24DA9 /* VLCTabAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VLCTabAdapter.h; sourceTree = "<group>"; };
 		D09EFF211C8CD49E00B24DA9 /* VLC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VLC.h; sourceTree = "<group>"; };
-		EC34526CCB5D146FD02423F4 /* Pods-BeardedSpiceControllers-BeardedSpice.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BeardedSpiceControllers-BeardedSpice.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice/Pods-BeardedSpiceControllers-BeardedSpice.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -472,7 +298,7 @@
 			files = (
 				65A8501A1C8DE9E000D54C77 /* CoreAudio.framework in Frameworks */,
 				65A850191C8DE9D900D54C77 /* Carbon.framework in Frameworks */,
-				1E1426F8950EBED0E2020816 /* libPods-BeardedSpiceControllers.a in Frameworks */,
+				57EC5B34F4AD4F87F5D44625 /* libPods-BeardedSpiceControllers.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -482,7 +308,8 @@
 			files = (
 				9679336518551BCC00A49AC7 /* ScriptingBridge.framework in Frameworks */,
 				967933301855173100A49AC7 /* Cocoa.framework in Frameworks */,
-				DAD858605B37FF09D3AAD082 /* libPods-BeardedSpiceControllers-BeardedSpice.a in Frameworks */,
+				0BD1B2F31CD21AA900B72A3E /* JavaScriptCore.framework in Frameworks */,
+				7D8A002D0E49A89BB9CB53DD /* libPods-BeardedSpiceControllers-BeardedSpice.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -490,28 +317,16 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0BD1B2F41CD21AB100B72A3E /* JavaScriptCore.framework in Frameworks */,
 				967933501855173100A49AC7 /* Cocoa.framework in Frameworks */,
 				9679334F1855173100A49AC7 /* XCTest.framework in Frameworks */,
-				C7EBE1D19BB5376934A3F6D3 /* libPods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.a in Frameworks */,
+				11A36C1600CD983E3627C87A /* libPods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		026BCA1451614966030FD4B5 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				7A9EAC832D8E08D9DFB67396 /* Pods-BeardedSpiceControllers.debug.xcconfig */,
-				9F9355D0AD84C962E403B8AB /* Pods-BeardedSpiceControllers.release.xcconfig */,
-				EC34526CCB5D146FD02423F4 /* Pods-BeardedSpiceControllers-BeardedSpice.debug.xcconfig */,
-				CBC84E9024D0B34C3324D861 /* Pods-BeardedSpiceControllers-BeardedSpice.release.xcconfig */,
-				2F6D87D0EA72A7C89F896C4E /* Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.debug.xcconfig */,
-				968406BFD21574C07B747F37 /* Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
 		0369231B1862934000E04DDB /* Preferences */ = {
 			isa = PBXGroup;
 			children = (
@@ -529,6 +344,8 @@
 				65E5670D1B76A07700AD2D46 /* BSMediaStrategyEnableButton.m */,
 				65E567121B775C9300AD2D46 /* BSShortcutView.h */,
 				65E567131B775C9300AD2D46 /* BSShortcutView.m */,
+				65ADE6031D169D0C000C29F1 /* EHVerticalCenteredTextField.h */,
+				65ADE6041D169D0C000C29F1 /* EHVerticalCenteredTextField.m */,
 			);
 			path = Preferences;
 			sourceTree = "<group>";
@@ -536,9 +353,9 @@
 		03F33EE31857E21100E8F77E /* Tabs */ = {
 			isa = PBXGroup;
 			children = (
-				5ECFDCD51CD8F8DE00811169 /* Downcast.h */,
-				5ECFDCD61CD8F8DE00811169 /* DowncastTabAdapter.h */,
-				5ECFDCD71CD8F8DE00811169 /* DowncastTabAdapter.m */,
+				5E80769C1D58CE180002855D /* Downcast.h */,
+				5E80769D1D58CE180002855D /* DowncastTabAdapter.h */,
+				5E80769E1D58CE180002855D /* DowncastTabAdapter.m */,
 				D09EFF1F1C8CD49E00B24DA9 /* VLCTabAdapter.m */,
 				D09EFF201C8CD49E00B24DA9 /* VLCTabAdapter.h */,
 				D09EFF211C8CD49E00B24DA9 /* VLC.h */,
@@ -565,81 +382,6 @@
 			path = Tabs;
 			sourceTree = "<group>";
 		};
-		0BF06A111C95139900534083 /* MediaStrategies */ = {
-			isa = PBXGroup;
-			children = (
-				0BF06A121C95139900534083 /* AmazonMusic.plist */,
-				0BF06A131C95139900534083 /* Audible.plist */,
-				0BF06A141C95139900534083 /* AudioMack.plist */,
-				0BF06A151C95139900534083 /* BandCamp.plist */,
-				0BF06A161C95139900534083 /* BBCRadio.plist */,
-				0BF06A171C95139900534083 /* Beatguide.plist */,
-				0BF06A181C95139900534083 /* BeatsMusic.plist */,
-				0BF06A191C95139900534083 /* Blitzr.plist */,
-				0BF06A1A1C95139900534083 /* BrainFm.plist */,
-				0BF06A1B1C95139900534083 /* BugsMusic.plist */,
-				0BF06A1C1C95139900534083 /* Chorus.plist */,
-				0BF06A1D1C95139900534083 /* Composed.plist */,
-				0BF06A1E1C95139900534083 /* Coursera.plist */,
-				0BF06A1F1C95139900534083 /* Deezer.plist */,
-				0BF06A201C95139900534083 /* DigitallyImported.plist */,
-				0BF06A211C95139900534083 /* EightTracks.plist */,
-				0BF06A221C95139900534083 /* FocusAtWill.plist */,
-				0BF06A231C95139900534083 /* GoogleMusic.plist */,
-				0BF06A241C95139900534083 /* GrooveShark.plist */,
-				0BF06A251C95139900534083 /* HotNewHipHop.plist */,
-				0BF06A261C95139900534083 /* HypeMachine.plist */,
-				0BF06A271C95139A00534083 /* iHeartRadio.plist */,
-				0BF06A281C95139A00534083 /* IndieShuffle.plist */,
-				0BF06A291C95139A00534083 /* Jango.plist */,
-				0BF06A2A1C95139A00534083 /* KollektFm.plist */,
-				0BF06A2B1C95139A00534083 /* LastFm.plist */,
-				0BF06A2C1C95139A00534083 /* LeTournedisque.plist */,
-				0BF06A2D1C95139A00534083 /* LogitechMediaServer.plist */,
-				0BF06A2E1C95139A00534083 /* MixCloud.plist */,
-				0BF06A2F1C95139A00534083 /* MusicForProgramming.plist */,
-				0BF06A301C95139A00534083 /* MusicUnlimited.plist */,
-				0BF06A311C95139A00534083 /* Netflix.plist */,
-				0BF06A321C95139A00534083 /* NoAdRadio.plist */,
-				0BF06A331C95139A00534083 /* NoonPacific.plist */,
-				0BF06A341C95139A00534083 /* NRK.plist */,
-				0BF06A351C95139A00534083 /* Odnoklassniki.plist */,
-				0BF06A361C95139A00534083 /* Overcast.plist */,
-				0BF06A371C95139A00534083 /* Pandora.plist */,
-				0BF06A381C95139A00534083 /* PlexWeb.plist */,
-				0BF06A391C95139A00534083 /* PocketCasts.plist */,
-				0BF06A3A1C95139A00534083 /* Rdio.plist */,
-				0BF06A3B1C95139A00534083 /* Rhapsody.plist */,
-				0BF06A3C1C95139A00534083 /* Saavn.plist */,
-				0BF06A3D1C95139A00534083 /* ShufflerFm.plist */,
-				0BF06A3E1C95139A00534083 /* Slacker.plist */,
-				0BF06A3F1C95139A00534083 /* SomaFm.plist */,
-				0BF06A401C95139A00534083 /* Songza.plist */,
-				0BF06A411C95139A00534083 /* SoundCloud.plist */,
-				0BF06A421C95139A00534083 /* Spotify.plist */,
-				0BF06A431C95139A00534083 /* Stitcher.plist */,
-				0BF06A441C95139A00534083 /* Subsonic.plist */,
-				0BF06A451C95139A00534083 /* Synology.plist */,
-				0BF06A461C95139A00534083 /* TidalHiFi.plist */,
-				0BF06A471C95139A00534083 /* TuneIn.plist */,
-				0BF06A481C95139A00534083 /* TwentyTwoTracks.plist */,
-				0BF06A491C95139A00534083 /* Twitch.plist */,
-				0BF06A4A1C95139A00534083 /* Udemy.plist */,
-				0BF06A4B1C95139A00534083 /* versions.plist */,
-				0BF06A4C1C95139A00534083 /* Vessel.plist */,
-				0BF06A4D1C95139A00534083 /* Vimeo.plist */,
-				0BF06A4E1C95139A00534083 /* Vk.plist */,
-				0BF06A4F1C95139A00534083 /* WatchaPlay.plist */,
-				0BF06A501C95139A00534083 /* WonderFm.plist */,
-				0BF06A511C95139A00534083 /* XboxMusic.plist */,
-				0BF06A521C95139A00534083 /* YandexMusic.plist */,
-				0BF06A531C95139A00534083 /* YandexRadio.plist */,
-				0BF06A541C95139A00534083 /* Youtube.plist */,
-			);
-			name = MediaStrategies;
-			path = BeardedSpice/MediaStrategies;
-			sourceTree = SOURCE_ROOT;
-		};
 		656A001D1C8AD3E200BD29F5 /* SPMediaKeyTap */ = {
 			isa = PBXGroup;
 			children = (
@@ -654,6 +396,10 @@
 		656A00241C8AD41A00BD29F5 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				655AACA51D3ABFAA00E316EA /* EHCCache.h */,
+				655AACA61D3ABFAA00E316EA /* EHCCache.m */,
+				655AACA71D3ABFAA00E316EA /* NSArray+Utils.h */,
+				655AACA81D3ABFAA00E316EA /* NSArray+Utils.m */,
 				656A00251C8AD41A00BD29F5 /* BSTimeout.h */,
 				656A00261C8AD41A00BD29F5 /* BSTimeout.m */,
 				656A00271C8AD41A00BD29F5 /* EHSystemUtils.h */,
@@ -743,7 +489,7 @@
 				967933531855173100A49AC7 /* BeardedSpiceTests */,
 				9679332E1855173100A49AC7 /* Frameworks */,
 				9679332D1855173100A49AC7 /* Products */,
-				026BCA1451614966030FD4B5 /* Pods */,
+				C5F7A2FBB1AC4C50850BCEEB /* Pods */,
 			);
 			indentWidth = 4;
 			sourceTree = "<group>";
@@ -764,16 +510,16 @@
 		9679332E1855173100A49AC7 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				0BD1B2F21CD21AA900B72A3E /* JavaScriptCore.framework */,
 				65E567071B76104300AD2D46 /* CoreAudio.framework */,
 				03F33ECB1855306A00E8F77E /* Carbon.framework */,
 				9679336418551BCC00A49AC7 /* ScriptingBridge.framework */,
 				9679332F1855173100A49AC7 /* Cocoa.framework */,
 				9679334E1855173100A49AC7 /* XCTest.framework */,
 				967933311855173100A49AC7 /* Other Frameworks */,
-				2299BC537DEC481A9540F7CA /* libPods.a */,
-				7F20B81547A29635C2DF0434 /* libPods-BeardedSpiceControllers.a */,
-				28CA978C46A156EA9D1CFA4A /* libPods-BeardedSpiceControllers-BeardedSpice.a */,
-				45EC506CE39EEDB80F99EA07 /* libPods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.a */,
+				7FAD2F3C92017C9093D70503 /* libPods-BeardedSpiceControllers.a */,
+				A13F7ACE82D7C5DF91641532 /* libPods-BeardedSpiceControllers-BeardedSpice.a */,
+				53666B3CA02A56F052042196 /* libPods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -791,15 +537,22 @@
 		967933351855173100A49AC7 /* BeardedSpice */ = {
 			isa = PBXGroup;
 			children = (
-				0BF06A111C95139900534083 /* MediaStrategies */,
+				65ABBAA81D1FDC5400F882CE /* Config.xcconfig */,
+				65D57FCF1D02E64F0016F270 /* Debug-Config.xcconfig */,
+				65D57FCA1D02CBFE0016F270 /* MediaStrategies */,
 				0369231B1862934000E04DDB /* Preferences */,
 				03F33EE31857E21100E8F77E /* Tabs */,
 				03A34920185EA43900C4A62B /* MediaStrategyRegistry.h */,
 				03A34921185EA43900C4A62B /* MediaStrategyRegistry.m */,
 				0BF06ADB1C9513A800534083 /* BSMediaStrategy.h */,
 				0BF06ADC1C9513A800534083 /* BSMediaStrategy.m */,
+				0BE8FFFA1CDA4F5B001A4DDF /* versions.plist */,
 				0BF06ADD1C9513A800534083 /* BSStrategyVersionManager.h */,
 				0BF06ADE1C9513A800534083 /* BSStrategyVersionManager.m */,
+				65ABBAA41D1EC7D000F882CE /* BSCustomStrategyManager.h */,
+				65ABBAA51D1EC7D000F882CE /* BSCustomStrategyManager.m */,
+				0B33014C1CFA643F0090DB67 /* BSStrategyCache.h */,
+				0B33014D1CFA643F0090DB67 /* BSStrategyCache.m */,
 				0BF06ADF1C9513A800534083 /* BSTrack.h */,
 				0BF06AE01C9513A800534083 /* BSTrack.m */,
 				6537DAA61AF396DA002F2391 /* NativeAppTabRegistry.h */,
@@ -820,10 +573,6 @@
 		967933361855173100A49AC7 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
-				0320C0531868C7A4009591CA /* beard-highlighted.png */,
-				17C5B63B18DB3649006F38C1 /* beard-highlighted@2x.png */,
-				0320C0511868C6C2009591CA /* beard.png */,
-				17C5B63918DB33C0006F38C1 /* beard@2x.png */,
 				030123391868B1F90080115F /* BeardedSpiceUserDefaults.plist */,
 				967933371855173100A49AC7 /* BeardedSpice-Info.plist */,
 				9679333B1855173100A49AC7 /* main.m */,
@@ -836,7 +585,11 @@
 		967933531855173100A49AC7 /* BeardedSpiceTests */ = {
 			isa = PBXGroup;
 			children = (
-				967933591855173100A49AC7 /* BeardedSpiceTests.m */,
+				0B1AF3761CCE4D4C0021BBEA /* BSMediaStrategyTests.m */,
+				0B1AF3771CCE4D4C0021BBEA /* BSStrategyMockObject.h */,
+				0B1AF3781CCE4D4C0021BBEA /* BSStrategyMockObject.m */,
+				0B1AF3791CCE4D4C0021BBEA /* BSStrategyTests.m */,
+				0B1AF37C1CCE4D4C0021BBEA /* BSTrackTests.m */,
 				967933541855173100A49AC7 /* Supporting Files */,
 			);
 			path = BeardedSpiceTests;
@@ -850,6 +603,19 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		C5F7A2FBB1AC4C50850BCEEB /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				91351FB7426B1A29959CEE4B /* Pods-BeardedSpiceControllers.debug.xcconfig */,
+				19F70640AA530B57CAE19126 /* Pods-BeardedSpiceControllers.release.xcconfig */,
+				47E7DF3674629C3865366CA8 /* Pods-BeardedSpiceControllers-BeardedSpice.debug.xcconfig */,
+				412BD1821FB849B7F1BABF75 /* Pods-BeardedSpiceControllers-BeardedSpice.release.xcconfig */,
+				2276A4EDC9C2D1AAD937291D /* Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.debug.xcconfig */,
+				2A913DB70FE33880FAD92004 /* Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -857,11 +623,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 656AFFF81C8ACDCF00BD29F5 /* Build configuration list for PBXNativeTarget "BeardedSpiceControllers" */;
 			buildPhases = (
-				2347A5CF8E47858340D7C44D /* [CP] Check Pods Manifest.lock */,
+				19168B7827BBC96768A4C0E7 /* [CP] Check Pods Manifest.lock */,
 				656AFFE61C8ACDCF00BD29F5 /* Sources */,
 				656AFFE71C8ACDCF00BD29F5 /* Frameworks */,
 				656AFFE81C8ACDCF00BD29F5 /* Resources */,
-				8449C49435F79BA2F22310E4 /* [CP] Copy Pods Resources */,
+				899723E2D1D7C2A165079678 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -876,14 +642,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 9679335D1855173100A49AC7 /* Build configuration list for PBXNativeTarget "BeardedSpice" */;
 			buildPhases = (
-				1B37E2ED2CE348E4A35365B6 /* [CP] Check Pods Manifest.lock */,
+				444DB68E61F8ED39440C7D99 /* [CP] Check Pods Manifest.lock */,
 				967933281855173100A49AC7 /* Sources */,
 				967933291855173100A49AC7 /* Frameworks */,
 				9679332A1855173100A49AC7 /* Resources */,
-				B3F72F996C864D30BAFDCE71 /* [CP] Copy Pods Resources */,
 				6564BDB01B74BF9C007030D8 /* Embed Frameworks */,
-				790986C3E0FD0317E1DDA091 /* [CP] Embed Pods Frameworks */,
 				656AFFF91C8ACDCF00BD29F5 /* Embed XPC Services */,
+				49DBE1128D0C0CE893BED11E /* [CP] Embed Pods Frameworks */,
+				503D914487498C5E5D4B381C /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -899,12 +665,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 967933601855173100A49AC7 /* Build configuration list for PBXNativeTarget "BeardedSpiceTests" */;
 			buildPhases = (
-				0F084B328AE6B23242C3A83D /* [CP] Check Pods Manifest.lock */,
+				AB9AD96DE64B6D494415BFF9 /* [CP] Check Pods Manifest.lock */,
 				967933491855173100A49AC7 /* Sources */,
 				9679334A1855173100A49AC7 /* Frameworks */,
 				9679334B1855173100A49AC7 /* Resources */,
-				5A7D0CA7032ECC0C24582AAF /* [CP] Embed Pods Frameworks */,
-				AAF2584D239BD6B936387DAD /* [CP] Copy Pods Resources */,
+				261B1E7D9347603186A50C0D /* [CP] Embed Pods Frameworks */,
+				189AA939D297EACACE65A248 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -957,73 +723,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0BF06AAC1C95139A00534083 /* ShufflerFm.plist in Resources */,
-				0BF06AC41C95139A00534083 /* Twitch.plist in Resources */,
-				0BF06A6E1C95139A00534083 /* Coursera.plist in Resources */,
-				0BF06A941C95139A00534083 /* Netflix.plist in Resources */,
-				0BF06A701C95139A00534083 /* Deezer.plist in Resources */,
-				0BF06A8E1C95139A00534083 /* MixCloud.plist in Resources */,
-				0BF06ABA1C95139A00534083 /* Subsonic.plist in Resources */,
-				0BF06A921C95139A00534083 /* MusicUnlimited.plist in Resources */,
-				0BF06AC01C95139A00534083 /* TuneIn.plist in Resources */,
-				0BF06A9E1C95139A00534083 /* Overcast.plist in Resources */,
-				0BF06ADA1C95139A00534083 /* Youtube.plist in Resources */,
-				0BF06A721C95139A00534083 /* DigitallyImported.plist in Resources */,
-				0BF06AD41C95139A00534083 /* XboxMusic.plist in Resources */,
-				0BF06A621C95139A00534083 /* BeatsMusic.plist in Resources */,
-				0BF06AB61C95139A00534083 /* Spotify.plist in Resources */,
-				0BF06ACE1C95139A00534083 /* Vk.plist in Resources */,
-				0BF06A9A1C95139A00534083 /* NRK.plist in Resources */,
-				0BF06A741C95139A00534083 /* EightTracks.plist in Resources */,
-				0BF06A5E1C95139A00534083 /* BBCRadio.plist in Resources */,
-				0BF06A561C95139A00534083 /* AmazonMusic.plist in Resources */,
-				0BF06AA81C95139A00534083 /* Rhapsody.plist in Resources */,
-				0BF06ABC1C95139A00534083 /* Synology.plist in Resources */,
-				0BF06A681C95139A00534083 /* BugsMusic.plist in Resources */,
-				0BF06A581C95139A00534083 /* Audible.plist in Resources */,
-				0BF06A8A1C95139A00534083 /* LeTournedisque.plist in Resources */,
-				0BF06AA61C95139A00534083 /* Rdio.plist in Resources */,
-				0BF06AC81C95139A00534083 /* versions.plist in Resources */,
-				0BF06AA21C95139A00534083 /* PlexWeb.plist in Resources */,
-				0BF06ACC1C95139A00534083 /* Vimeo.plist in Resources */,
-				0BF06AD21C95139A00534083 /* WonderFm.plist in Resources */,
-				0BF06A7E1C95139A00534083 /* HypeMachine.plist in Resources */,
-				0BF06AD01C95139A00534083 /* WatchaPlay.plist in Resources */,
-				0BF06A981C95139A00534083 /* NoonPacific.plist in Resources */,
-				0BF06AC21C95139A00534083 /* TwentyTwoTracks.plist in Resources */,
-				0BF06A961C95139A00534083 /* NoAdRadio.plist in Resources */,
-				0BF06AA01C95139A00534083 /* Pandora.plist in Resources */,
-				0BF06AB21C95139A00534083 /* Songza.plist in Resources */,
-				0BF06AAA1C95139A00534083 /* Saavn.plist in Resources */,
-				0BF06AAE1C95139A00534083 /* Slacker.plist in Resources */,
-				0BF06ACA1C95139A00534083 /* Vessel.plist in Resources */,
-				0BF06AB41C95139A00534083 /* SoundCloud.plist in Resources */,
-				0BF06A781C95139A00534083 /* GoogleMusic.plist in Resources */,
-				0BF06AD61C95139A00534083 /* YandexMusic.plist in Resources */,
-				0BF06A6A1C95139A00534083 /* Chorus.plist in Resources */,
-				0BF06A7A1C95139A00534083 /* GrooveShark.plist in Resources */,
-				0BF06A5C1C95139A00534083 /* BandCamp.plist in Resources */,
-				0BF06A901C95139A00534083 /* MusicForProgramming.plist in Resources */,
-				0BF06A661C95139A00534083 /* BrainFm.plist in Resources */,
-				0BF06AD81C95139A00534083 /* YandexRadio.plist in Resources */,
-				0BF06A641C95139A00534083 /* Blitzr.plist in Resources */,
-				0BF06A8C1C95139A00534083 /* LogitechMediaServer.plist in Resources */,
-				0BF06AB01C95139A00534083 /* SomaFm.plist in Resources */,
-				0BF06A761C95139A00534083 /* FocusAtWill.plist in Resources */,
-				0BF06A821C95139A00534083 /* IndieShuffle.plist in Resources */,
-				0BF06A861C95139A00534083 /* KollektFm.plist in Resources */,
-				0BF06ABE1C95139A00534083 /* TidalHiFi.plist in Resources */,
-				0BF06A5A1C95139A00534083 /* AudioMack.plist in Resources */,
-				0BF06A7C1C95139A00534083 /* HotNewHipHop.plist in Resources */,
-				0BF06A9C1C95139A00534083 /* Odnoklassniki.plist in Resources */,
-				0BF06A881C95139A00534083 /* LastFm.plist in Resources */,
-				0BF06AC61C95139A00534083 /* Udemy.plist in Resources */,
-				0BF06A841C95139A00534083 /* Jango.plist in Resources */,
-				0BF06A6C1C95139A00534083 /* Composed.plist in Resources */,
-				0BF06AB81C95139A00534083 /* Stitcher.plist in Resources */,
-				0BF06A601C95139A00534083 /* Beatguide.plist in Resources */,
-				0BF06A801C95139A00534083 /* iHeartRadio.plist in Resources */,
-				0BF06AA41C95139A00534083 /* PocketCasts.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1031,83 +730,14 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0BF06AA31C95139A00534083 /* PocketCasts.plist in Resources */,
-				0BF06A6F1C95139A00534083 /* Deezer.plist in Resources */,
-				0BF06AA91C95139A00534083 /* Saavn.plist in Resources */,
-				0BF06A8D1C95139A00534083 /* MixCloud.plist in Resources */,
 				967933481855173100A49AC7 /* Images.xcassets in Resources */,
-				0BF06AA51C95139A00534083 /* Rdio.plist in Resources */,
-				0BF06AAD1C95139A00534083 /* Slacker.plist in Resources */,
-				0BF06ABF1C95139A00534083 /* TuneIn.plist in Resources */,
-				0BF06AD91C95139A00534083 /* Youtube.plist in Resources */,
-				0BF06A9F1C95139A00534083 /* Pandora.plist in Resources */,
-				0BF06A811C95139A00534083 /* IndieShuffle.plist in Resources */,
 				65EE28A11AB6003B00EFC886 /* ShortcutsPreferencesView.xib in Resources */,
-				0BF06A5D1C95139A00534083 /* BBCRadio.plist in Resources */,
-				0BF06A571C95139A00534083 /* Audible.plist in Resources */,
-				0BF06A8F1C95139A00534083 /* MusicForProgramming.plist in Resources */,
-				0BF06A951C95139A00534083 /* NoAdRadio.plist in Resources */,
-				0BF06A851C95139A00534083 /* KollektFm.plist in Resources */,
-				0BF06A7F1C95139A00534083 /* iHeartRadio.plist in Resources */,
-				0BF06AB11C95139A00534083 /* Songza.plist in Resources */,
-				0BF06AD11C95139A00534083 /* WonderFm.plist in Resources */,
-				0BF06A6B1C95139A00534083 /* Composed.plist in Resources */,
-				0BF06A931C95139A00534083 /* Netflix.plist in Resources */,
-				0BF06A7D1C95139A00534083 /* HypeMachine.plist in Resources */,
-				0BF06A8B1C95139A00534083 /* LogitechMediaServer.plist in Resources */,
 				0B355EF71CBEA3350089C2B3 /* Localizable.strings in Resources */,
-				0BF06ABD1C95139A00534083 /* TidalHiFi.plist in Resources */,
-				0BF06AAF1C95139A00534083 /* SomaFm.plist in Resources */,
-				0320C0521868C6C2009591CA /* beard.png in Resources */,
 				0301233A1868B1F90080115F /* BeardedSpiceUserDefaults.plist in Resources */,
-				0BF06A751C95139A00534083 /* FocusAtWill.plist in Resources */,
-				0BF06A771C95139A00534083 /* GoogleMusic.plist in Resources */,
-				0BF06ACF1C95139A00534083 /* WatchaPlay.plist in Resources */,
-				0BF06ACB1C95139A00534083 /* Vimeo.plist in Resources */,
-				0BF06AC11C95139A00534083 /* TwentyTwoTracks.plist in Resources */,
-				0BF06A711C95139A00534083 /* DigitallyImported.plist in Resources */,
-				0BF06AD31C95139A00534083 /* XboxMusic.plist in Resources */,
-				0BF06A911C95139A00534083 /* MusicUnlimited.plist in Resources */,
-				0BF06A971C95139A00534083 /* NoonPacific.plist in Resources */,
-				0BF06A7B1C95139A00534083 /* HotNewHipHop.plist in Resources */,
 				65EE289E1AB6003800EFC886 /* GeneralPreferencesView.xib in Resources */,
-				0BF06AA71C95139A00534083 /* Rhapsody.plist in Resources */,
-				0320C0541868C7A4009591CA /* beard-highlighted.png in Resources */,
-				0BF06A551C95139A00534083 /* AmazonMusic.plist in Resources */,
-				0BF06A791C95139A00534083 /* GrooveShark.plist in Resources */,
+				65D57FCB1D02CBFE0016F270 /* MediaStrategies in Resources */,
 				967933461855173100A49AC7 /* MainMenu.xib in Resources */,
-				0BF06AB71C95139A00534083 /* Stitcher.plist in Resources */,
-				0BF06A611C95139A00534083 /* BeatsMusic.plist in Resources */,
-				0BF06AA11C95139A00534083 /* PlexWeb.plist in Resources */,
-				17C5B63C18DB3649006F38C1 /* beard-highlighted@2x.png in Resources */,
-				0BF06AC31C95139A00534083 /* Twitch.plist in Resources */,
-				0BF06AB51C95139A00534083 /* Spotify.plist in Resources */,
-				0BF06AD51C95139A00534083 /* YandexMusic.plist in Resources */,
-				0BF06A9B1C95139A00534083 /* Odnoklassniki.plist in Resources */,
-				0BF06A5F1C95139A00534083 /* Beatguide.plist in Resources */,
-				17C5B63A18DB33C0006F38C1 /* beard@2x.png in Resources */,
-				0BF06A651C95139A00534083 /* BrainFm.plist in Resources */,
-				0BF06AAB1C95139A00534083 /* ShufflerFm.plist in Resources */,
-				0BF06A5B1C95139A00534083 /* BandCamp.plist in Resources */,
-				0BF06A991C95139A00534083 /* NRK.plist in Resources */,
-				0BF06A891C95139A00534083 /* LeTournedisque.plist in Resources */,
-				0BF06A9D1C95139A00534083 /* Overcast.plist in Resources */,
-				0BF06ABB1C95139A00534083 /* Synology.plist in Resources */,
-				0BF06AB91C95139A00534083 /* Subsonic.plist in Resources */,
-				0BF06A831C95139A00534083 /* Jango.plist in Resources */,
-				0BF06A631C95139A00534083 /* Blitzr.plist in Resources */,
-				0BF06A591C95139A00534083 /* AudioMack.plist in Resources */,
-				0BF06AC51C95139A00534083 /* Udemy.plist in Resources */,
-				0BF06AD71C95139A00534083 /* YandexRadio.plist in Resources */,
-				0BF06A871C95139A00534083 /* LastFm.plist in Resources */,
-				0BF06AC71C95139A00534083 /* versions.plist in Resources */,
-				0BF06A691C95139A00534083 /* Chorus.plist in Resources */,
-				0BF06A6D1C95139A00534083 /* Coursera.plist in Resources */,
-				0BF06AC91C95139A00534083 /* Vessel.plist in Resources */,
-				0BF06A731C95139A00534083 /* EightTracks.plist in Resources */,
-				0BF06A671C95139A00534083 /* BugsMusic.plist in Resources */,
-				0BF06AB31C95139A00534083 /* SoundCloud.plist in Resources */,
-				0BF06ACD1C95139A00534083 /* Vk.plist in Resources */,
+				0BE800771CDA4F5B001A4DDF /* versions.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1115,103 +745,15 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				65D57FCC1D02CC250016F270 /* MediaStrategies in Resources */,
+				0BE800781CDA4F5B001A4DDF /* versions.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		0F084B328AE6B23242C3A83D /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		1B37E2ED2CE348E4A35365B6 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		2347A5CF8E47858340D7C44D /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		5A7D0CA7032ECC0C24582AAF /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests/Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		790986C3E0FD0317E1DDA091 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice/Pods-BeardedSpiceControllers-BeardedSpice-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		8449C49435F79BA2F22310E4 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-BeardedSpiceControllers/Pods-BeardedSpiceControllers-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		AAF2584D239BD6B936387DAD /* [CP] Copy Pods Resources */ = {
+		189AA939D297EACACE65A248 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1226,7 +768,67 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests/Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		B3F72F996C864D30BAFDCE71 /* [CP] Copy Pods Resources */ = {
+		19168B7827BBC96768A4C0E7 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice/Pods-BeardedSpiceControllers-BeardedSpice-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		261B1E7D9347603186A50C0D /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests/Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		444DB68E61F8ED39440C7D99 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice/Pods-BeardedSpiceControllers-BeardedSpice-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		49DBE1128D0C0CE893BED11E /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice/Pods-BeardedSpiceControllers-BeardedSpice-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		503D914487498C5E5D4B381C /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1241,6 +843,36 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-BeardedSpiceControllers-BeardedSpice/Pods-BeardedSpiceControllers-BeardedSpice-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		899723E2D1D7C2A165079678 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		AB9AD96DE64B6D494415BFF9 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -1248,6 +880,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0BF9CAE71CFFDB2F00E9986B /* NSString+Utils.m in Sources */,
 				656A00141C8AD3C800BD29F5 /* DDHidAppleRemote.m in Sources */,
 				656A00231C8AD3E200BD29F5 /* SPMediaKeyTap.m in Sources */,
 				656A00321C8AD41A00BD29F5 /* EHSystemUtils.m in Sources */,
@@ -1255,7 +888,6 @@
 				65A850161C8B065000D54C77 /* BSCService.m in Sources */,
 				656AFFF11C8ACDCF00BD29F5 /* main.m in Sources */,
 				65A8501D1C9330F800D54C77 /* BSCShortcutMonitor.m in Sources */,
-				656A00361C8AD41A00BD29F5 /* NSString+Utils.m in Sources */,
 				656A00221C8AD3E200BD29F5 /* NSObject+SPInvocationGrabbing.m in Sources */,
 				656A003E1C8B01BC00BD29F5 /* BSSharedDefaults.m in Sources */,
 				656A001C1C8AD3C800BD29F5 /* NSXReturnThrowError.m in Sources */,
@@ -1278,10 +910,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5ECFDCD81CD8F8DE00811169 /* DowncastTabAdapter.m in Sources */,
 				0369231F1862936600E04DDB /* GeneralPreferencesViewController.m in Sources */,
 				0BF06AE51C9513A800534083 /* BSTrack.m in Sources */,
+				655AACAA1D3ABFAA00E316EA /* NSArray+Utils.m in Sources */,
 				967933431855173100A49AC7 /* AppDelegate.m in Sources */,
+				65ADE6051D169D0C000C29F1 /* EHVerticalCenteredTextField.m in Sources */,
 				65E567111B76AE3A00AD2D46 /* BSPreferencesWindowController.m in Sources */,
 				6537DAAD1AF6E666002F2391 /* SpotifyTabAdapter.m in Sources */,
 				D09EFF221C8CD49E00B24DA9 /* VLCTabAdapter.m in Sources */,
@@ -1296,6 +929,7 @@
 				03F33EF01857E59B00E8F77E /* SafariTabAdapter.m in Sources */,
 				6588CF461B3584A700A3CBAD /* VOXTabAdapter.m in Sources */,
 				656A00311C8AD41A00BD29F5 /* EHSystemUtils.m in Sources */,
+				65ABBAA61D1EC7D000F882CE /* BSCustomStrategyManager.m in Sources */,
 				0BF06AE11C9513A800534083 /* BSMediaStrategy.m in Sources */,
 				656A00331C8AD41A00BD29F5 /* NSException+Utils.m in Sources */,
 				65E567141B775C9300AD2D46 /* BSShortcutView.m in Sources */,
@@ -1305,6 +939,9 @@
 				6537DAA81AF396DA002F2391 /* NativeAppTabRegistry.m in Sources */,
 				65B32B8E1AD99D1600F696B9 /* TabAdapter.m in Sources */,
 				03F33EED1857E3C000E8F77E /* ChromeTabAdapter.m in Sources */,
+				655AACA91D3ABFAA00E316EA /* EHCCache.m in Sources */,
+				5E80769F1D58CE180002855D /* DowncastTabAdapter.m in Sources */,
+				0B33014E1CFA643F0090DB67 /* BSStrategyCache.m in Sources */,
 				656A002F1C8AD41A00BD29F5 /* BSTimeout.m in Sources */,
 				0BF06AE31C9513A800534083 /* BSStrategyVersionManager.m in Sources */,
 				6537DAAB1AF508DF002F2391 /* MediaControllerObject.m in Sources */,
@@ -1315,7 +952,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9679335A1855173100A49AC7 /* BeardedSpiceTests.m in Sources */,
+				0B1AF37F1CCE4D4C0021BBEA /* BSStrategyMockObject.m in Sources */,
+				0B1AF37E1CCE4D4C0021BBEA /* BSMediaStrategyTests.m in Sources */,
+				0B33014F1CFA643F0090DB67 /* BSStrategyCache.m in Sources */,
+				0B1AF3831CCE4D4C0021BBEA /* BSTrackTests.m in Sources */,
+				65D57FCE1D02CD140016F270 /* BSMediaStrategy.m in Sources */,
+				65D57FCD1D02CCB00016F270 /* NSURL+Utils.m in Sources */,
+				0B1AF3801CCE4D4C0021BBEA /* BSStrategyTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1372,18 +1015,17 @@
 /* Begin XCBuildConfiguration section */
 		656AFFF61C8ACDCF00BD29F5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7A9EAC832D8E08D9DFB67396 /* Pods-BeardedSpiceControllers.debug.xcconfig */;
+			baseConfigurationReference = 91351FB7426B1A29959CEE4B /* Pods-BeardedSpiceControllers.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = BeardedSpiceControllers/Info.plist;
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.beardedspice.BeardedSpiceControllers;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1393,18 +1035,17 @@
 		};
 		656AFFF71C8ACDCF00BD29F5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9F9355D0AD84C962E403B8AB /* Pods-BeardedSpiceControllers.release.xcconfig */;
+			baseConfigurationReference = 19F70640AA530B57CAE19126 /* Pods-BeardedSpiceControllers.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = BeardedSpiceControllers/Info.plist;
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.beardedspice.BeardedSpiceControllers;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1414,6 +1055,7 @@
 		};
 		9679335B1855173100A49AC7 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 65D57FCF1D02E64F0016F270 /* Debug-Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -1436,6 +1078,7 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
+					"JSC_OBJC_API_ENABLED=1",
 					"$(inherited)",
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
@@ -1445,7 +1088,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
 			};
@@ -1453,6 +1096,7 @@
 		};
 		9679335C1855173100A49AC7 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 65ABBAA81D1FDC5400F882CE /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -1472,25 +1116,29 @@
 				ENABLE_NS_ASSERTIONS = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"JSC_OBJC_API_ENABLED=1",
+					"$(inherited)",
+				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				SDKROOT = macosx;
 			};
 			name = Release;
 		};
 		9679335E1855173100A49AC7 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EC34526CCB5D146FD02423F4 /* Pods-BeardedSpiceControllers-BeardedSpice.debug.xcconfig */;
+			baseConfigurationReference = 47E7DF3674629C3865366CA8 /* Pods-BeardedSpiceControllers-BeardedSpice.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1508,12 +1156,12 @@
 		};
 		9679335F1855173100A49AC7 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CBC84E9024D0B34C3324D861 /* Pods-BeardedSpiceControllers-BeardedSpice.release.xcconfig */;
+			baseConfigurationReference = 412BD1821FB849B7F1BABF75 /* Pods-BeardedSpiceControllers-BeardedSpice.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1531,9 +1179,10 @@
 		};
 		967933611855173100A49AC7 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2F6D87D0EA72A7C89F896C4E /* Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.debug.xcconfig */;
+			baseConfigurationReference = 2276A4EDC9C2D1AAD937291D /* Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.debug.xcconfig */;
 			buildSettings = {
-				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/BeardedSpice.app/Contents/MacOS/BeardedSpice";
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -1543,23 +1192,21 @@
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "BeardedSpice/BeardedSpice-Prefix.pch";
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
 				INFOPLIST_FILE = "BeardedSpiceTests/BeardedSpiceTests-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "foo.bar.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = BeardedSpiceTests;
-				TEST_HOST = "$(BUNDLE_LOADER)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BeardedSpice.app/Contents/MacOS/BeardedSpice";
+				USER_HEADER_SEARCH_PATHS = "";
 				WRAPPER_EXTENSION = xctest;
 			};
 			name = Debug;
 		};
 		967933621855173100A49AC7 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 968406BFD21574C07B747F37 /* Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.release.xcconfig */;
+			baseConfigurationReference = 2A913DB70FE33880FAD92004 /* Pods-BeardedSpiceControllers-BeardedSpice-BeardedSpiceTests.release.xcconfig */;
 			buildSettings = {
-				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/BeardedSpice.app/Contents/MacOS/BeardedSpice";
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -1572,7 +1219,7 @@
 				INFOPLIST_FILE = "BeardedSpiceTests/BeardedSpiceTests-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "foo.bar.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = BeardedSpiceTests;
-				TEST_HOST = "$(BUNDLE_LOADER)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BeardedSpice.app/Contents/MacOS/BeardedSpice";
 				WRAPPER_EXTENSION = xctest;
 			};
 			name = Release;

--- a/BeardedSpice/NativeAppTabRegistry.m
+++ b/BeardedSpice/NativeAppTabRegistry.m
@@ -12,6 +12,7 @@
 #import "SpotifyTabAdapter.h"
 #import "VOXTabAdapter.h"
 #import "VLCTabAdapter.h"
+#import "DowncastTabAdapter.h"
 
 @implementation NativeAppTabRegistry
 
@@ -74,7 +75,8 @@ static NativeAppTabRegistry *singletonNativeAppTabRegistry;
         [iTunesTabAdapter class],
         [SpotifyTabAdapter class],
         [VLCTabAdapter class],
-        [VOXTabAdapter class]
+        [VOXTabAdapter class],
+        [DowncastTabAdapter class]
     ];
 }
 

--- a/BeardedSpice/Tabs/Downcast.h
+++ b/BeardedSpice/Tabs/Downcast.h
@@ -1,0 +1,43 @@
+/*
+ * Downcast.h
+ */
+
+#import <AppKit/AppKit.h>
+#import <ScriptingBridge/ScriptingBridge.h>
+
+
+@class DowncastApplication, DowncastNowPlayingInfo;
+
+
+
+/*
+ * Downcast Script Suite
+ */
+
+// The application's top-level scripting object.
+@interface DowncastApplication : SBApplication
+
+@property (copy, readonly) DowncastNowPlayingInfo *nowPlayingInfo;
+
+- (void) playpause;  // Toggles play/pause state. Pauses if currently playing, plays if currently paused
+- (void) play;  // Plays if currently paused
+- (void) pause;  // Pauses if currently playing
+- (void) next;
+- (void) previous;
+
+@end
+
+@interface DowncastNowPlayingInfo : SBObject
+
+@property (copy, readonly) NSString *episodeTitle;
+@property (copy, readonly) NSString *sourceTitle;  // The title of the podcast or playlist this episode is being played from.
+@property NSInteger duration;
+@property NSInteger playPosition;
+@property (copy, readonly) NSString *mediaURL;
+@property (copy, readonly) NSString *publisher;
+@property (copy, readonly) NSData *artworkData;
+@property (readonly) BOOL isPlaying;
+
+
+@end
+

--- a/BeardedSpice/Tabs/DowncastTabAdapter.h
+++ b/BeardedSpice/Tabs/DowncastTabAdapter.h
@@ -1,0 +1,13 @@
+//
+//  DowncastTabAdapter.h
+//  BeardedSpice
+//
+//  Created by George Cox on 5/2/16.
+//  Copyright © 2016 BeardedSpice. All rights reserved.
+//
+
+#import "NativeAppTabAdapter.h"
+
+@interface DowncastTabAdapter : NativeAppTabAdapter
+
+@end

--- a/BeardedSpice/Tabs/DowncastTabAdapter.m
+++ b/BeardedSpice/Tabs/DowncastTabAdapter.m
@@ -1,0 +1,131 @@
+//
+//  DowncastTabAdapter.m
+//  BeardedSpice
+//
+//  Created by George Cox on 5/2/16.
+//  Copyright © 2016 BeardedSpice. All rights reserved.
+//
+
+#import "DowncastTabAdapter.h"
+#import "Downcast.h"
+#import "runningSBApplication.h"
+#import "NSString+Utils.h"
+#import "BSMediaStrategy.h"
+#import "BSTrack.h"
+
+#define APPNAME_DOWNCAST         @"Downcast"
+#define APPID_DOWNCAST           @"com.jamawkinaw.downcast.mac"
+
+@implementation DowncastTabAdapter
+
++ (NSString *)displayName{
+    
+    return APPNAME_DOWNCAST;
+}
+
++ (NSString *)bundleId{
+    
+    return APPID_DOWNCAST;
+}
+
+- (DowncastApplication *)downcast {
+    return (DowncastApplication *)[self.application sbApplication];
+}
+- (NSString *)title {
+    
+    @autoreleasepool {
+        DowncastNowPlayingInfo *npi = self.downcast.nowPlayingInfo;
+        NSString *title;
+        if (![NSString isNullOrEmpty:npi.episodeTitle])
+            title = npi.episodeTitle;
+        
+        if (![NSString isNullOrEmpty:npi.publisher]) {
+            if (title)
+                title = [title stringByAppendingFormat:@" - %@", npi.publisher];
+            else
+                title = npi.publisher;
+        }
+        
+        if ([NSString isNullOrEmpty:title]) {
+            title = NSLocalizedString(@"No Track", @"DowncastTabAdapter");
+        }
+        
+        return [NSString stringWithFormat:@"%@ (%@)", title, APPNAME_DOWNCAST];
+    }
+}
+- (NSString *)URL{
+    
+    return @"Downcast";
+}
+
+// We have only one window.
+- (NSString *)key{
+    
+    return @"A:Downcast";
+}
+
+// We have only one window.
+-(BOOL) isEqual:(__autoreleasing id)otherTab{
+    
+    if (otherTab == nil || ![otherTab isKindOfClass:[DowncastTabAdapter class]]) return NO;
+    
+    return YES;
+}
+
+//////////////////////////////////////////////////////////////
+#pragma mark Player control methods
+//////////////////////////////////////////////////////////////
+
+- (void)toggle{
+    DowncastApplication *downcast = self.downcast;
+    if (downcast) {
+        [downcast playpause];
+    }
+}
+- (void)pause{
+    DowncastApplication *downcast = self.downcast;
+    if (downcast) {
+        [downcast pause];
+    }
+}
+- (void)next{
+    DowncastApplication *downcast = self.downcast;
+    if (downcast) {
+        [downcast next];
+    }
+}
+- (void)previous{
+    DowncastApplication *downcast = self.downcast;
+    if (downcast) {
+        [downcast previous];
+    }
+}
+
+- (BSTrack *)trackInfo{
+    DowncastApplication *downcast = self.downcast;
+    if (downcast) {
+        BSTrack *track = [BSTrack new];
+        DowncastNowPlayingInfo *npi = downcast.nowPlayingInfo;
+        track.track = npi.episodeTitle;
+        track.album = npi.sourceTitle;
+        track.artist = npi.publisher;
+        NSData *artworkData = [npi.artworkData copy];
+        if (artworkData != nil) {
+            track.image = [[NSImage alloc] initWithData:artworkData];
+        }
+        return track;
+    }
+    
+    return nil;
+}
+
+- (BOOL)isPlaying{
+    DowncastApplication *downcast = self.downcast;
+    if (downcast) {
+        DowncastNowPlayingInfo *npi = downcast.nowPlayingInfo;
+        return npi != nil && npi.isPlaying;
+    }
+    return NO;
+}
+
+@end

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ From the preferences tab, uncheck any types of webpages that you don't want Bear
 - [Spotify](https://www.spotify.com/)
 - [VLC](http://www.videolan.org/vlc/)
 - [VOX](http://coppertino.com/)
+- [Downcast](http://downcast.fm/)
 
 ### Supported Sites
 - [8Tracks](http://8tracks.com)


### PR DESCRIPTION
#355 

~~An update for Downcast which adds the required AppleScript support for this is currently awaiting review in the Mac App Store (submitted on 8/7/16).~~ The most recent version of [Downcast (v2.9.16)](https://itunes.apple.com/us/app/downcast/id668429425?mt=12) contains the required AppleScript support.