### PR TITLE
Fix mike not working after it's unplugged and plugged back in

### DIFF
--- a/BeardedSpice.xcodeproj/project.pbxproj
+++ b/BeardedSpice.xcodeproj/project.pbxproj
@@ -63,7 +63,7 @@
 		656AFFEF1C8ACDCF00BD29F5 /* BeardedSpiceControllers.m in Sources */ = {isa = PBXBuildFile; fileRef = 656AFFEE1C8ACDCF00BD29F5 /* BeardedSpiceControllers.m */; };
 		656AFFF11C8ACDCF00BD29F5 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 656AFFF01C8ACDCF00BD29F5 /* main.m */; };
 		656AFFF51C8ACDCF00BD29F5 /* BeardedSpiceControllers.xpc in Embed XPC Services */ = {isa = PBXBuildFile; fileRef = 656AFFEA1C8ACDCF00BD29F5 /* BeardedSpiceControllers.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		656AFFFD1C8AD3B400BD29F5 /* BSHeadphoneUnplugListener.m in Sources */ = {isa = PBXBuildFile; fileRef = 656AFFFC1C8AD3B400BD29F5 /* BSHeadphoneUnplugListener.m */; };
+		656AFFFD1C8AD3B400BD29F5 /* BSHeadphoneStatusListener.m in Sources */ = {isa = PBXBuildFile; fileRef = 656AFFFC1C8AD3B400BD29F5 /* BSHeadphoneStatusListener.m */; };
 		657EAEA91AAAEB9300D00456 /* runningSBApplication.m in Sources */ = {isa = PBXBuildFile; fileRef = 657EAEA81AAAEB9300D00456 /* runningSBApplication.m */; };
 		6588CF461B3584A700A3CBAD /* VOXTabAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 6588CF451B3584A700A3CBAD /* VOXTabAdapter.m */; };
 		65A850161C8B065000D54C77 /* BSCService.m in Sources */ = {isa = PBXBuildFile; fileRef = 65A850151C8B065000D54C77 /* BSCService.m */; };
@@ -232,8 +232,8 @@
 		656AFFEE1C8ACDCF00BD29F5 /* BeardedSpiceControllers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BeardedSpiceControllers.m; sourceTree = "<group>"; };
 		656AFFF01C8ACDCF00BD29F5 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		656AFFF21C8ACDCF00BD29F5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		656AFFFB1C8AD3B400BD29F5 /* BSHeadphoneUnplugListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSHeadphoneUnplugListener.h; sourceTree = "<group>"; };
-		656AFFFC1C8AD3B400BD29F5 /* BSHeadphoneUnplugListener.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSHeadphoneUnplugListener.m; sourceTree = "<group>"; };
+		656AFFFB1C8AD3B400BD29F5 /* BSHeadphoneStatusListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSHeadphoneStatusListener.h; sourceTree = "<group>"; };
+		656AFFFC1C8AD3B400BD29F5 /* BSHeadphoneStatusListener.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSHeadphoneStatusListener.m; sourceTree = "<group>"; };
 		656AFFFF1C8AD3C800BD29F5 /* DDHidAppleMikey.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDHidAppleMikey.h; sourceTree = "<group>"; };
 		657EAEA71AAAEB9300D00456 /* runningSBApplication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = runningSBApplication.h; sourceTree = "<group>"; };
 		657EAEA81AAAEB9300D00456 /* runningSBApplication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = runningSBApplication.m; sourceTree = "<group>"; };
@@ -442,8 +442,8 @@
 		656AFFFA1C8AD37E00BD29F5 /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
-				656AFFFB1C8AD3B400BD29F5 /* BSHeadphoneUnplugListener.h */,
-				656AFFFC1C8AD3B400BD29F5 /* BSHeadphoneUnplugListener.m */,
+				656AFFFB1C8AD3B400BD29F5 /* BSHeadphoneStatusListener.h */,
+				656AFFFC1C8AD3B400BD29F5 /* BSHeadphoneStatusListener.m */,
 				65A8501B1C9330F800D54C77 /* BSCShortcutMonitor.h */,
 				65A8501C1C9330F800D54C77 /* BSCShortcutMonitor.m */,
 				656A001D1C8AD3E200BD29F5 /* SPMediaKeyTap */,
@@ -897,7 +897,7 @@
 				656A00181C8AD3C800BD29F5 /* DDHidQueue.m in Sources */,
 				656A00381C8AD41A00BD29F5 /* NSURL+Utils.m in Sources */,
 				656A00131C8AD3C800BD29F5 /* DDHidAppleMikey.m in Sources */,
-				656AFFFD1C8AD3B400BD29F5 /* BSHeadphoneUnplugListener.m in Sources */,
+				656AFFFD1C8AD3B400BD29F5 /* BSHeadphoneStatusListener.m in Sources */,
 				656A001B1C8AD3C800BD29F5 /* NSDictionary+DDHidExtras.m in Sources */,
 				656A001A1C8AD3C800BD29F5 /* DDHidUsageTables.m in Sources */,
 				656A00191C8AD3C800BD29F5 /* DDHidUsage.m in Sources */,

--- a/BeardedSpiceControllers/BSCService.h
+++ b/BeardedSpiceControllers/BSCService.h
@@ -7,10 +7,10 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "BSHeadphoneUnplugListener.h"
+#import "BSHeadphoneStatusListener.h"
 #import "Shortcut.h"
 
-@interface BSCService : NSObject < BSHeadphoneUnplugListenerProtocol >
+@interface BSCService : NSObject < BSHeadphoneStatusListenerProtocol >
 
 + (BSCService *)singleton;
 

--- a/BeardedSpiceControllers/BSCService.m
+++ b/BeardedSpiceControllers/BSCService.m
@@ -26,7 +26,7 @@
     SPMediaKeyTap *_keyTap;
     NSMutableArray *_mikeys;
     NSMutableArray *_appleRemotes;
-    BSHeadphoneUnplugListener *_hpuListener;
+    BSHeadphoneStatusListener *_hpuListener;
 
     NSMutableDictionary *_shortcuts;
 
@@ -57,7 +57,7 @@ static BSCService *bscSingleton;
 
             workingQueue = dispatch_queue_create("BeardedSpiceControllerService", DISPATCH_QUEUE_SERIAL);
 
-            _hpuListener = [[BSHeadphoneUnplugListener alloc] initWithDelegate:self];
+            _hpuListener = [[BSHeadphoneStatusListener alloc] initWithDelegate:self];
             _keyTap = [[SPMediaKeyTap alloc] initWithDelegate:self];
 
 
@@ -246,6 +246,13 @@ static BSCService *bscSingleton;
 - (void)headphoneUnplugAction{
 
     [self sendMessagesToConnections:@selector(headphoneUnplug)];
+}
+
+- (void)headphonePlugAction
+{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [self refreshMikeys];
+    });
 }
 
 -(void)mediaKeyTap:(SPMediaKeyTap*)keyTap receivedMediaKeyEvent:(NSEvent*)event;

--- a/BeardedSpiceControllers/Controllers/BSHeadphoneStatusListener.h
+++ b/BeardedSpiceControllers/Controllers/BSHeadphoneStatusListener.h
@@ -13,12 +13,17 @@
 #pragma mark - BSHeadphoneUnplugListener
 /////////////////////////////////////////////////////////////////////
 
-@protocol BSHeadphoneUnplugListenerProtocol <NSObject>
+@protocol BSHeadphoneStatusListenerProtocol <NSObject>
 
 /**
     Action is called when headphone is unplugged.
  */
 - (void)headphoneUnplugAction;
+
+/**
+ Action is called when headphone is plugged in.
+ */
+- (void)headphonePlugAction;
 
 @end
 
@@ -31,7 +36,7 @@
     Attempt to determine unplugging headphone from it. 
     And perform action when raises this event.
  */
-@interface BSHeadphoneUnplugListener : NSObject{
+@interface BSHeadphoneStatusListener : NSObject{
     
     AudioDeviceID _defaultDevice;
     UInt32        _sourceId;
@@ -47,13 +52,13 @@
 #pragma mark Init and class methods
 /////////////////////////////////////////////////////////////////////
 
-- (BSHeadphoneUnplugListener *)initWithDelegate:(id<BSHeadphoneUnplugListenerProtocol>)delegate;
+- (BSHeadphoneStatusListener *)initWithDelegate:(id<BSHeadphoneStatusListenerProtocol>)delegate;
 
 /////////////////////////////////////////////////////////////////////
 #pragma mark Properties and public methods
 /////////////////////////////////////////////////////////////////////
 
-@property (weak, readonly, nonatomic) id<BSHeadphoneUnplugListenerProtocol> delegate;
+@property (weak, readonly, nonatomic) id<BSHeadphoneStatusListenerProtocol> delegate;
 
 @property BOOL enabled;
 

--- a/BeardedSpiceControllers/Controllers/BSHeadphoneStatusListener.m
+++ b/BeardedSpiceControllers/Controllers/BSHeadphoneStatusListener.m
@@ -6,19 +6,19 @@
 //  Copyright (c) 2015 BeardedSpice. All rights reserved.
 //
 
-#import "BSHeadphoneUnplugListener.h"
+#import "BSHeadphoneStatusListener.h"
 
 /////////////////////////////////////////////////////////////////////
 #pragma mark - BSHeadphoneUnplugListener
 /////////////////////////////////////////////////////////////////////
 
-@implementation BSHeadphoneUnplugListener
+@implementation BSHeadphoneStatusListener
 
 /////////////////////////////////////////////////////////////////////
 #pragma mark Init and class methods
 /////////////////////////////////////////////////////////////////////
 
-- (BSHeadphoneUnplugListener *)initWithDelegate:(id<BSHeadphoneUnplugListenerProtocol>)delegate{
+- (BSHeadphoneStatusListener *)initWithDelegate:(id<BSHeadphoneStatusListenerProtocol>)delegate{
     
     if (!delegate) {
         return nil;
@@ -42,18 +42,24 @@
         
         AudioObjectGetPropertyData(kAudioObjectSystemObject, &defaultAddr, 0, NULL, &defaultSize, &_defaultDevice);
         
-        __weak BSHeadphoneUnplugListener *bself = self;
+        __weak BSHeadphoneStatusListener *bself = self;
         _listenerBlock = ^(UInt32 inNumberAddresses,
                            const AudioObjectPropertyAddress *inAddresses) {
             
             UInt32 newSourceId = [bself currentSource:(AudioObjectPropertyAddress *)inAddresses];
             
-            if (_sourceId == 'hdpn' && _sourceId != newSourceId) {
-                dispatch_async(dispatch_get_current_queue(), ^{
-                    [bself.delegate headphoneUnplugAction];
-                });
+            if (_sourceId != newSourceId) {
+                if (_sourceId == 'hdpn') {
+                    dispatch_async(dispatch_get_current_queue(), ^{
+                        [bself.delegate headphoneUnplugAction];
+                    });
+                } else if (newSourceId == 'hdpn') {
+                    dispatch_async(dispatch_get_current_queue(), ^{
+                        [bself.delegate headphonePlugAction];
+                    });
+                }
+                _sourceId = newSourceId;
             }
-            _sourceId = newSourceId;
         };
      
         _enabled = NO;


### PR DESCRIPTION
I noticed this bug while using the app. If you unplug apple earphones and then plug them back in, media controls from the headphones stop working(volume +- and toggle). Running refreshMikeys a few seconds after headphones are plugged back in seems to fix the issue.