### PR TITLE
Mixcloud beta compatibility

### DIFF
--- a/BeardedSpice/MediaStrategies/MixCloud.js
+++ b/BeardedSpice/MediaStrategies/MixCloud.js
@@ -10,7 +10,7 @@ BSStrategy = {
   displayName:"MixCloud",
   accepts: {
     method: "predicateOnTab",
-    format:"%K LIKE[c] '*mixcloud.com*'",
+    format:"%K LIKE[c] '*www.mixcloud.com*'",
     args: ["URL"]
   },
   isPlaying: function() {return (document.querySelector('.player-control.pause-state') != null)},

--- a/BeardedSpice/MediaStrategies/MixCloud.js
+++ b/BeardedSpice/MediaStrategies/MixCloud.js
@@ -7,7 +7,7 @@
 //
 BSStrategy = {
   version:2,
-  displayName:"MixCloud",
+  displayName:"Mixcloud",
   accepts: {
     method: "predicateOnTab",
     format:"%K LIKE[c] '*www.mixcloud.com*'",

--- a/BeardedSpice/MediaStrategies/MixcloudBeta.js
+++ b/BeardedSpice/MediaStrategies/MixcloudBeta.js
@@ -1,0 +1,23 @@
+//
+//  MixcloudBeta.plist
+//  BeardedSpice
+//
+BSStrategy = {
+  version:2,
+  displayName:"Mixcloud Beta",
+  accepts: {
+    method: "predicateOnTab",
+    format:"%K LIKE[c] '*beta.mixcloud.com*'",
+    args: ["URL"]
+  },
+  isPlaying: function() {return (document.querySelector('.mz-player-control.mz-pause-state') != null)},
+  pause: function () { var aButton = document.querySelector('.mz-player-control.mz-pause-state'); if(aButton) aButton.click() },
+  toggle: function () { document.querySelector('.mz-player-control').click(); },
+  trackInfo: function () {
+    return {
+      'track': document.querySelector('.mz-player-cloudcast-title').text,
+      'artist': document.querySelector('.mz-player-cloudcast-author-link').text,
+      'image' : document.querySelector('div.mz-player img.loaded').getAttribute('src')
+    }
+  }
+}

--- a/BeardedSpice/MediaStrategies/versions.plist
+++ b/BeardedSpice/MediaStrategies/versions.plist
@@ -68,7 +68,7 @@
 	<integer>1</integer>
 	<key>LogitechMediaServer</key>
 	<integer>1</integer>
-	<key>MixCloud</key>
+	<key>Mixcloud</key>
 	<integer>2</integer>
 	<key>Mixcloud Beta</key>
 	<integer>1</integer>

--- a/BeardedSpice/MediaStrategies/versions.plist
+++ b/BeardedSpice/MediaStrategies/versions.plist
@@ -70,6 +70,8 @@
 	<integer>1</integer>
 	<key>MixCloud</key>
 	<integer>2</integer>
+	<key>Mixcloud Beta</key>
+	<integer>1</integer>
 	<key>MusicForProgramming</key>
 	<integer>1</integer>
 	<key>MusicUnlimited</key>


### PR DESCRIPTION
Hey guys,

I am one of Mixcloud's developers and we recently launched our new beta site. You can go [here](https://www.mixcloud.com/beta/join) if you would like to join.

The CSS class names on the player have changed so Bearded Spice is currently broken on the Beta site. I created a second MediaStrategy called `MixcloudBeta.js` since both sites are running at the moment. When we launch the new site I will make the necessary changes and merge the two files.
