### PR TITLE
Updated Google Music Media Strategy

### DIFF
--- a/BeardedSpice/MediaStrategies/GoogleMusic.js
+++ b/BeardedSpice/MediaStrategies/GoogleMusic.js
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Tyler Rhodes / Jose Falcon. All rights reserved.
 //
 BSStrategy = {
-  version:1,
+  version:2,
   displayName:"GoogleMusic",
   accepts: {
     method: "predicateOnTab",
@@ -32,7 +32,7 @@ BSStrategy = {
       'track':  document.getElementById('currently-playing-title').innerText,
       'album':  document.getElementsByClassName('player-album')[0].innerText,
       'artist': document.getElementById('player-artist').innerText,
-      'image':  document.getElementById('playingBarArt').getAttribute('src')
+      'image':  document.getElementById('playerBarArt').getAttribute('src')
     }
   }
 }

--- a/BeardedSpice/MediaStrategies/versions.plist
+++ b/BeardedSpice/MediaStrategies/versions.plist
@@ -49,7 +49,7 @@
 	<key>Gaana</key>
 	<integer>1</integer>
 	<key>GoogleMusic</key>
-	<integer>1</integer>
+	<integer>2</integer>
 	<key>GrooveShark</key>
 	<integer>1</integer>
 	<key>HotNewHipHop</key>


### PR DESCRIPTION
- I have slightly updated the Google Music Media Strategy. 
- The element ID for album artwork is `playerBarArt`, not `playingBarArt` which the strategy was using. 
- This update allows BeardedSpice to correctly display track info for Google Music tracks.