### PR TITLE
Fixed "No Track" bug in title return for iTunesTabAdapter

### DIFF
--- a/BeardedSpice/Tabs/iTunesTabAdapter.m
+++ b/BeardedSpice/Tabs/iTunesTabAdapter.m
@@ -44,7 +44,7 @@
     @autoreleasepool {
 
         iTunesApplication *iTunes = (iTunesApplication *)[self.application sbApplication];
-        iTunesTrack *currentTrack = [[iTunes currentTrack] get];
+        iTunesTrack *currentTrack = [iTunes currentTrack];
 
         NSString *title;
         if (currentTrack) {


### PR DESCRIPTION
See [issue #509](https://github.com/beardedspice/beardedspice/issues/509) where I have laid out the problem.