### PR TITLE
Added strategy to deal with band camp white label sites

### DIFF
--- a/BeardedSpice/MediaStrategies/BandCampWhiteLabel.js
+++ b/BeardedSpice/MediaStrategies/BandCampWhiteLabel.js
@@ -3,7 +3,7 @@
 //  BeardedSpice
 //
 //  Copied from BandCamp.js and editted by Jon Bramley on 23/11/2016.
-//  Copyright (c) 2013 Tyler Rhodes / Jose Falcon. All rights reserved.
+// Copyright (c) 2015-2016 GPL v3 http://www.gnu.org/licenses/gpl.html
 //
 BSStrategy = {
   version:1,

--- a/BeardedSpice/MediaStrategies/BandCampWhiteLabel.js
+++ b/BeardedSpice/MediaStrategies/BandCampWhiteLabel.js
@@ -1,0 +1,28 @@
+//
+//  BandCamp.plist
+//  BeardedSpice
+//
+//  Created by Jose Falcon on 12/16/13.
+//  Copyright (c) 2013 Tyler Rhodes / Jose Falcon. All rights reserved.
+//
+BSStrategy = {
+  version:1,
+  displayName:"BandCampWhiteLabel",
+  accepts: {
+    method: "script",
+    script: function () {
+      return (RegExp("https?://bandcamp\.com").test(siteroot));
+    }
+  },
+  toggle: function () {gplaylist.playpause()},
+  next: function () {gplaylist.next_track()},
+  previous: function () {gplaylist.prev_track()},
+  pause: function () {gplaylist.pause()},
+  trackInfo: function () {
+    return {
+      'artist': EmbedData.artist,
+      'album': EmbedData.album_title,
+      'track': gplaylist.get_track_info().title
+    }
+  }
+}

--- a/BeardedSpice/MediaStrategies/BandCampWhiteLabel.js
+++ b/BeardedSpice/MediaStrategies/BandCampWhiteLabel.js
@@ -2,7 +2,7 @@
 //  BandCamp.plist
 //  BeardedSpice
 //
-//  Created by Jose Falcon on 12/16/13.
+//  Copied from BandCamp.js and editted by Jon Bramley on 23/11/2016.
 //  Copyright (c) 2013 Tyler Rhodes / Jose Falcon. All rights reserved.
 //
 BSStrategy = {

--- a/BeardedSpice/MediaStrategies/versions.plist
+++ b/BeardedSpice/MediaStrategies/versions.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BandCampWhiteLabel</key>
+	<integer>1</integer>
 	<key>StyleJukebox</key>
 	<integer>1</integer>
 	<key>AmazonMusic</key>


### PR DESCRIPTION
Some record labels are now white labelling Bandcamp, so the URL no longer contains any reference to bandcamp.com. This means that BeardedSpice fails to recognise these as Bandcamp.

I have added a new Media Strategy (copied from bandcamp.js) which detects these white labels by reading the siteroot variable. Tested successfully on http://furtherrecords.org/album/anterior-space and http://recordstore.planetgroucho.com/album/motion-sickness

Thanks!