### PR TITLE
Update Udemy MediaStrategy for Late 2016

### DIFF
--- a/BeardedSpice/MediaStrategies/Udemy.js
+++ b/BeardedSpice/MediaStrategies/Udemy.js
@@ -3,29 +3,30 @@
 //  BeardedSpice
 //
 //  Created by Coder-256 on 10/3/15.
-//  Copyright © 2015 BeardedSpice. All rights reserved.
+//  Updated by nelsonjchen on 11/24/16.
+//  Copyright © 2016 BeardedSpice. All rights reserved.
 //
 BSStrategy = {
-  version:1,
+  version:2,
   displayName:"Udemy",
   accepts: {
     method: "predicateOnTab",
     format:"%K LIKE[c] '*udemy.com*/lecture/*'",
     args: ["URL"]
   },
-  isPlaying: function () {return !(document.querySelector('div.ud-lectureangular > iframe').contentWindow.document.querySelector('video').paused);},
+  isPlaying: function () {return !(document.querySelector('video-player video').paused);},
   toggle: function () {
-    var theVideo = document.querySelector('div.ud-lectureangular > iframe').contentWindow.document.getElementsByTagName("video")[0];
+    var theVideo = document.querySelector('video-player video');
     if (theVideo.paused) { theVideo.play(); }
     else { theVideo.pause() }
   },
-  next: function () {document.querySelector('div.ud-lectureangular > iframe').parent().parent().parent().find(".prev-lecture")[0].click();},
+  next: function () {document.querySelector("a.udi.udi-vjs-forward.btn").click()},
   favorite: function () {},
-  previous: function () {document.querySelector('div.ud-lectureangular > iframe').parent().parent().next().find(".next-lecture")[0].click();},
-  pause: function () {document.querySelector('div.ud-lectureangular > iframe').contentWindow.document.getElementsByTagName("video")[0].pause();},
+  previous: function () {document.querySelector("a.udi.udi-vjs-rewind.btn").click()},
+  pause: function () {document.querySelector('video-player video').pause();},
   trackInfo: function () {
     return {
-      'track': document.querySelector('.curriculum-item.on .ci-title').innerText,
+      'track': document.querySelector('.course-info__title').textContent,
       'album': 'Udemy'
     }
   }

--- a/BeardedSpice/MediaStrategies/versions.plist
+++ b/BeardedSpice/MediaStrategies/versions.plist
@@ -147,7 +147,7 @@
 	<key>Twitch</key>
 	<integer>1</integer>
 	<key>Udemy</key>
-	<integer>1</integer>
+	<integer>2</integer>
 	<key>Vessel</key>
 	<integer>1</integer>
 	<key>Vimeo</key>


### PR DESCRIPTION
 * Replaced Previous and Next - The "Previous" lecture button is now
    missing and while "Next" lecture could still be implemented, I opted to
    replace the functionality. I made "Next" scrub forward 15 seconds
    and "Previous" scrub backwards 15 seconds as in the GUI.

* Updated the selectors to handle the newer non-iFrame Angular UI.