### PR TITLE
Replace Track Notification

### DIFF
--- a/BeardedSpice/AppDelegate.m
+++ b/BeardedSpice/AppDelegate.m
@@ -1014,6 +1014,10 @@ BOOL accessibilityApiEnabled = NO;
                 if (!([NSString isNullOrEmpty:track.track] &&
                       [NSString isNullOrEmpty:track.artist] &&
                       [NSString isNullOrEmpty:track.album])) {
+                    
+                    // Remove previous notification.
+                    [[NSUserNotificationCenter defaultUserNotificationCenter] removeDeliveredNotification:[track asNotification]];
+                    
                     [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:[track asNotification]];
                     NSLog(@"Show Notification: %@", track);
                 } else if (useFallback) {

--- a/BeardedSpice/BSTrack.m
+++ b/BeardedSpice/BSTrack.m
@@ -71,6 +71,7 @@ NSString *const kBSTrackNameFavorited = @"favorited";
 {
     NSUserNotification *notification = [[NSUserNotification alloc] init];
 
+    notification.identifier = @"BSTrack Notification";
     notification.title = self.track;
     notification.subtitle = self.album;
     notification.informativeText = self.artist;


### PR DESCRIPTION
Fixes #520
Add an identifier to track notification. Allows matching track
notifications with differing contents.
Remove the previous track notification before displaying a new one.