### PR TITLE
Clickable Track Notification

### DIFF
--- a/BeardedSpice/AppDelegate.m
+++ b/BeardedSpice/AppDelegate.m
@@ -183,6 +183,12 @@ BOOL accessibilityApiEnabled = NO;
     return YES;
 }
 
+- (void)userNotificationCenter:(NSUserNotificationCenter *)center didActivateNotification:(NSUserNotification *)notification{
+    if ([kBSTrackNameIdentifier isEqualToString:notification.identifier]) {
+        [self activatePlayingTab];
+    }
+}
+
 
 /////////////////////////////////////////////////////////////////////////
 #pragma mark BeardedSpiceHostAppProtocol methods

--- a/BeardedSpice/AppDelegate.m
+++ b/BeardedSpice/AppDelegate.m
@@ -1014,6 +1014,10 @@ BOOL accessibilityApiEnabled = NO;
                 if (!([NSString isNullOrEmpty:track.track] &&
                       [NSString isNullOrEmpty:track.artist] &&
                       [NSString isNullOrEmpty:track.album])) {
+                    
+                    // Remove previous notification.
+                    [[NSUserNotificationCenter defaultUserNotificationCenter] removeDeliveredNotification:[track asNotification]];
+                    
                     [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:[track asNotification]];
                     NSLog(@"Show Notification: %@", track);
                 } else if (useFallback) {

--- a/BeardedSpice/BSTrack.h
+++ b/BeardedSpice/BSTrack.h
@@ -11,6 +11,7 @@ extern NSString *const kBSTrackNameTrack;
 extern NSString *const kBSTrackNameAlbum;
 extern NSString *const kBSTrackNameArtist;
 extern NSString *const kBSTrackNameFavorited;
+extern NSString *const kBSTrackNameIdentifier;
 
 @interface BSTrack : NSObject
 

--- a/BeardedSpice/BSTrack.m
+++ b/BeardedSpice/BSTrack.m
@@ -71,6 +71,7 @@ NSString *const kBSTrackNameFavorited = @"favorited";
 {
     NSUserNotification *notification = [[NSUserNotification alloc] init];
 
+    notification.identifier = @"BSTrack Notification";
     notification.title = self.track;
     notification.subtitle = self.album;
     notification.informativeText = self.artist;

--- a/BeardedSpice/BSTrack.m
+++ b/BeardedSpice/BSTrack.m
@@ -13,6 +13,7 @@ NSString *const kBSTrackNameTrack = @"track";
 NSString *const kBSTrackNameAlbum = @"album";
 NSString *const kBSTrackNameArtist = @"artist";
 NSString *const kBSTrackNameFavorited = @"favorited";
+NSString *const kBSTrackNameIdentifier = @"BSTrack Notification";
 
 @interface BSTrack ()
 
@@ -71,7 +72,7 @@ NSString *const kBSTrackNameFavorited = @"favorited";
 {
     NSUserNotification *notification = [[NSUserNotification alloc] init];
 
-    notification.identifier = @"BSTrack Notification";
+    notification.identifier = kBSTrackNameIdentifier;
     notification.title = self.track;
     notification.subtitle = self.album;
     notification.informativeText = self.artist;


### PR DESCRIPTION
When clicking a track notification, the user is taken to the active playing tab. Fixes #531.

Builds off PR #532:
Fixes #520
Add an identifier to track notification. Allows matching track
notifications with differing contents.
Remove the previous track notification before displaying a new one.