### PR TITLE
Fixed release notes

### DIFF
--- a/Scripts/Resources/appcast.xmlTemplate
+++ b/Scripts/Resources/appcast.xmlTemplate
@@ -8,10 +8,10 @@
         <item>
             <title>${XML_APP_VERSION_TITLE}</title>
             <sparkle:releaseNotesLink>
-                https://htmlpreview.github.com/?${XML_BASEURL}/${XML_RELEASE_NOTES}-en.html
+                https://htmlpreview.github.io/?${XML_BASEURL}/${XML_RELEASE_NOTES}-en.html
             </sparkle:releaseNotesLink>
             <sparkle:releaseNotesLink xml:lang="en">
-                https://htmlpreview.github.com/?${XML_BASEURL}/${XML_RELEASE_NOTES}-en.html
+                https://htmlpreview.github.io/?${XML_BASEURL}/${XML_RELEASE_NOTES}-en.html
             </sparkle:releaseNotesLink>
             <pubDate>${XML_RELEASE_TIME}</pubDate>
             <sparkle:minimumSystemVersion>10.8</sparkle:minimumSystemVersion>

--- a/publish/beardedspice-appcast.xml
+++ b/publish/beardedspice-appcast.xml
@@ -8,10 +8,10 @@
         <item>
             <title>Version 2.1.2</title>
             <sparkle:releaseNotesLink>
-                https://htmlpreview.github.com/?https://raw.github.com/beardedspice/beardedspice/distr/publish/beardedspice-rnotes-en.html
+                https://htmlpreview.github.io/?https://raw.github.com/beardedspice/beardedspice/distr/publish/beardedspice-rnotes-en.html
             </sparkle:releaseNotesLink>
             <sparkle:releaseNotesLink xml:lang="en">
-                https://htmlpreview.github.com/?https://raw.github.com/beardedspice/beardedspice/distr/publish/beardedspice-rnotes-en.html
+                https://htmlpreview.github.io/?https://raw.github.com/beardedspice/beardedspice/distr/publish/beardedspice-rnotes-en.html
             </sparkle:releaseNotesLink>
             <pubDate>Thu, 15 Dec 2016 07:08:00 +0000</pubDate>
             <sparkle:minimumSystemVersion>10.8</sparkle:minimumSystemVersion>


### PR DESCRIPTION
This should fix the release notes.
The current https://htmlpreview.github.com/... doesn't work because it redirects to http://htmlpreview.github.io/...

This uses https://htmlpreview.github.io/ so it doesn't redirect to github.io and is served over https