### PR TITLE
Fixed wonderfm controls, added prev-track functionality

### DIFF
--- a/BeardedSpice/MediaStrategies/WonderFm.js
+++ b/BeardedSpice/MediaStrategies/WonderFm.js
@@ -3,42 +3,78 @@
 //  BeardedSpice
 //
 //  Created by Kyle Conarro on 2/3/15.
+//  Edited  by Richard Schreiber on 12/18/16
 //  Copyright (c) 2015 Tyler Rhodes / Jose Falcon. All rights reserved.
 //
 BSStrategy = {
-  version:1,
-  displayName:"WonderFM",
-  accepts: {
-    method: "predicateOnTab",
-    format:"%K LIKE[c] '*wonder.fm*'",
-    args: ["URL"]
-  },
-  isPlaying: function () {return $('div.jp-audio').hasClass('jp-state-playing');},
-  toggle: function () {
-    var e = document.querySelector('.jp-type-single');
-    var u = 'none' === getComputedStyle(e,null).display;
-    var n = 'none' === getComputedStyle(l,null).display;
-    if (u) {
-      var c = document.querySelector('.track_play');
-      c.click();
+    version: 1,
+    displayName: "WonderFM",
+    accepts: {
+        method: "predicateOnTab",
+        format: "%K LIKE[c] '*wonder.fm*'",
+        args: ["URL"]
+    },
+    isPlaying: function () {
+        var isPlaying = !document.querySelector(".show--activeTrack .player-play").classList.contains("ng-hide");
+        return isPlaying;
+    },
+    toggle: function () {
+        var isPlaying = !document.querySelector(".show--activeTrack .player-play").classList.contains("ng-hide");
+        var btn = isPlaying ? document.querySelector(".show--activeTrack .player-pause") : document.querySelector(".show--activeTrack .player-play");
+        var evt = document.createEvent("MouseEvents");
+
+        evt.initMouseEvent("click", true, true, window, 1, 0, 0, 0, 0,
+                false, false, false, false, 0, null);
+        btn.dispatchEvent(evt);
+    },
+    next: function () {
+        var btn = document.querySelector(".show--activeTrack .player-skip");
+        var evt = document.createEvent("MouseEvents");
+
+        evt.initMouseEvent("click", true, true, window, 1, 0, 0, 0, 0,
+                false, false, false, false, 0, null);
+        btn.dispatchEvent(evt);
+    },
+    favorite:function () {
+        var btn = document.querySelector(".track--active .track-fav");
+        var evt = document.createEvent("MouseEvents");
+
+        evt.initMouseEvent("click", true, true, window, 1, 0, 0, 0, 0,
+                false, false, false, false, 0, null);
+        btn.dispatchEvent(evt);
+    },
+    previous: function () {
+        var t = document.querySelector(".track--active"),
+            p = document.querySelector(".player__scrubber");
+        if (!t) {return;}
+        if (p && p.value > 0.01) {/* rewind instead of previous song if playhead further than 1% */
+            t = p;
+        }
+        else {
+            while (t = t.previousSibling) {
+                if (t.classList && t.classList.contains("track")) {break;}
+            }   
+        }
+        if (t) {
+            var evt = document.createEvent("MouseEvents");
+
+            evt.initMouseEvent("click", true, true, window, 1, 0, 0, 0, 0,
+                    false, false, false, false, 0, null);
+            t.dispatchEvent(evt);
+        }
+    },
+    pause: function () {
+        var btn = document.querySelector(".show--activeTrack .player-pause");
+        var evt = document.createEvent("MouseEvents");
+
+        evt.initMouseEvent("click", true, true, window, 1, 0, 0, 0, 0,
+                false, false, false, false, 0, null);
+        btn.dispatchEvent(evt);
+    },
+    trackInfo: function () {
+        return {
+            "track": document.querySelector(".track--active .track-name > a").text,
+            "artist": document.querySelector(".track--active .track-artist > a").text
+        };
     }
-    else if (n) {
-      var t = document.querySelector('a.jp-pause');
-      t.click();
-    }
-    else {
-      var l = document.querySelector('a.jp-play');
-      l.click();
-    }
-  },
-  next: function () {document.querySelector('a.jp-next').click()},
-  favorite:function () { document.querySelector('.track_active .track_fav').click() },
-  previous: function () {},
-  pause: function () {document.querySelector('a.jp-pause').click()},
-  trackInfo: function () {
-    return {
-      'track': document.querySelector('.track_active .track_name > a').text,
-      'artist': document.querySelector('.track_active .track_artist > a').text
-    }
-  }
-}
+};

--- a/BeardedSpice/MediaStrategies/WonderFm.js
+++ b/BeardedSpice/MediaStrategies/WonderFm.js
@@ -1,13 +1,13 @@
 //
-//  WonderFm.plist
+//  WonderFm.js
 //  BeardedSpice
 //
 //  Created by Kyle Conarro on 2/3/15.
 //  Edited  by Richard Schreiber on 12/18/16
-//  Copyright (c) 2015 Tyler Rhodes / Jose Falcon. All rights reserved.
+//  Copyright (c) 2016 GPL v3 http://www.gnu.org/licenses/gpl.html
 //
 BSStrategy = {
-    version: 1,
+    version: 2,
     displayName: "WonderFM",
     accepts: {
         method: "predicateOnTab",

--- a/BeardedSpice/MediaStrategies/versions.plist
+++ b/BeardedSpice/MediaStrategies/versions.plist
@@ -157,7 +157,7 @@
 	<key>WatchaPlay</key>
 	<integer>1</integer>
 	<key>WonderFm</key>
-	<integer>1</integer>
+	<integer>2</integer>
 	<key>XboxMusic</key>
 	<integer>2</integer>
 	<key>YandexMusic</key>


### PR DESCRIPTION
Due to a wonderfm-update needed to update CSS-selectors and use dispatchEvent

Info: I tried to refactor dispatchEvent into a local function inside a closure
doing an iife worked (at least it returned the object), but did not create a closure