### PR TITLE
Add second Pandora strategy for late 2016 interface update

### DIFF
--- a/BeardedSpice/MediaStrategies/Pandora2016.js
+++ b/BeardedSpice/MediaStrategies/Pandora2016.js
@@ -28,7 +28,7 @@ BSStrategy = {
       'track': document.querySelector('.nowPlayingTopInfo__current__trackName .Marquee__wrapper__content__child').innerText,
       'artist': document.querySelector('.nowPlayingTopInfo__current__artistName').innerText,
       'album': document.querySelector('.nowPlayingTopInfo__current__albumName').innerText,
-      'image': document.querySelector('[data-qa=album_active_image').style['background-image'].slice(5, -2),
+      'image': document.querySelector('[data-qa=album_active_image]').style['background-image'].slice(5, -2),
       'favorited': document.querySelector('[data-qa=thumbs_up_button]').classList.contains('ThumbUpButton--active')
     };
   }

--- a/BeardedSpice/MediaStrategies/Pandora2016.js
+++ b/BeardedSpice/MediaStrategies/Pandora2016.js
@@ -1,0 +1,35 @@
+//
+//  Pandora2016.js
+//  BeardedSpice
+//
+//  Created by Bret Martin on 2016-12-19
+//
+//  Copyright (c) 2015 GPL v3 http://www.gnu.org/licenses/gpl.html
+//
+
+BSStrategy = {
+  version: 1,
+  displayName: "Pandora (late 2016)",
+  accepts: {
+    method: "predicateOnTab",
+    format: "%K LIKE[c] '*pandora.com*'",
+    args: ["URL"]
+  },
+
+  isPlaying: function () {
+    document.querySelector('.Tuner__Control__Play__Button').attributes['data-qa'].value === 'play_button'
+  },
+  toggle: function () { document.querySelector('.Tuner__Control__Play__Button').click(); },
+  next: function () { document.querySelector('.Tuner__Control__Skip__Button').click(); },
+  pause: function () { document.querySelector('.Tuner__Control__Play__Button').click(); },
+  favorite: function() { document.querySelector('.Tuner__Control__ThumbUp__Button').click(); },
+  trackInfo: function () {
+    return {
+      'track': document.querySelector('.nowPlayingTopInfo__current__trackName .Marquee__wrapper__content__child').innerText,
+      'artist': document.querySelector('.nowPlayingTopInfo__current__artistName').innerText,
+      'album': document.querySelector('.nowPlayingTopInfo__current__albumName').innerText,
+      'image': document.querySelector('[data-qa=album_active_image').style['background-image'].slice(5, -2),
+      'favorited': document.querySelector('[data-qa=thumbs_up_button]').classList.contains('ThumbUpButton--active')
+    };
+  }
+}

--- a/BeardedSpice/MediaStrategies/versions.plist
+++ b/BeardedSpice/MediaStrategies/versions.plist
@@ -100,6 +100,8 @@
 	<integer>1</integer>
 	<key>Pandora</key>
 	<integer>2</integer>
+	<key>Pandora2016</key>
+	<integer>1</integer>
 	<key>PlexWeb</key>
 	<integer>3</integer>
 	<key>PocketCasts</key>


### PR DESCRIPTION
Pandora is rolling out a UI update to a subset of its users. Because of this, I think two strategies will need to co-exist for some time. Please let me know if you'd like me to change the naming of this in some way to be clearer.