### PR TITLE
BandCamp White Label : be more defensive with siteroot

### DIFF
--- a/BeardedSpice/MediaStrategies/BandCampWhiteLabel.js
+++ b/BeardedSpice/MediaStrategies/BandCampWhiteLabel.js
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015-2016 GPL v3 http://www.gnu.org/licenses/gpl.html
 //
 BSStrategy = {
-  version:1,
+  version: 2,
   displayName:"BandCampWhiteLabel",
   accepts: {
     method: "script",

--- a/BeardedSpice/MediaStrategies/BandCampWhiteLabel.js
+++ b/BeardedSpice/MediaStrategies/BandCampWhiteLabel.js
@@ -3,7 +3,7 @@
 //  BeardedSpice
 //
 //  Copied from BandCamp.js and editted by Jon Bramley on 23/11/2016.
-// Copyright (c) 2015-2016 GPL v3 http://www.gnu.org/licenses/gpl.html
+//  Copyright (c) 2015-2016 GPL v3 http://www.gnu.org/licenses/gpl.html
 //
 BSStrategy = {
   version:1,
@@ -11,7 +11,7 @@ BSStrategy = {
   accepts: {
     method: "script",
     script: function () {
-      return (RegExp("https?://bandcamp\.com").test(siteroot));
+      return window.siteroot ? RegExp("https?://bandcamp\.com").test(window.siteroot) : false;
     }
   },
   toggle: function () {gplaylist.playpause()},

--- a/BeardedSpice/MediaStrategies/versions.plist
+++ b/BeardedSpice/MediaStrategies/versions.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>BandCampWhiteLabel</key>
-	<integer>1</integer>
+	<integer>2</integer>
 	<key>StyleJukebox</key>
 	<integer>1</integer>
 	<key>AmazonMusic</key>


### PR DESCRIPTION
Sometime the siteroot check could cause errors in unrelated websites, we
should check it before using it.