### PR TITLE
Add support for optional new Pandora UI

### DIFF
--- a/BeardedSpice/MediaStrategies/Pandora.js
+++ b/BeardedSpice/MediaStrategies/Pandora.js
@@ -21,7 +21,7 @@ BSStrategy = {
         document
           .querySelector('.Tuner__Control__Play__Button')
           .attributes['data-qa']
-          .value === 'play_button';
+          .value === 'pause_button';
     } else {
       return document.querySelector('.pauseButton').style.display === 'block';
     }

--- a/BeardedSpice/MediaStrategies/Pandora.js
+++ b/BeardedSpice/MediaStrategies/Pandora.js
@@ -1,10 +1,11 @@
 //
-//  Pandora.plist
+//  Pandora.js
 //  BeardedSpice
 //
-//  Created by Jose Falcon on 12/16/13.
-//  Copyright (c) 2013 Tyler Rhodes / Jose Falcon. All rights reserved.
-//  Modified by Anthony Whitaker on 12/13/16
+//  Created by Jose Falcon on 2013-12-16
+//  Updated by Anthony Whitaker on 2016-12-13
+//  Support for new UI added by Bret Martin on 2017-01-01
+//  Copyright (c) 2013-2017 GPL v3 http://www.gnu.org/licenses/gpl.html
 //
 BSStrategy = {
   version: 3,

--- a/BeardedSpice/MediaStrategies/Pandora.js
+++ b/BeardedSpice/MediaStrategies/Pandora.js
@@ -7,7 +7,7 @@
 //  Modified by Anthony Whitaker on 12/13/16
 //
 BSStrategy = {
-  version: 2,
+  version: 3,
   displayName: "Pandora",
   accepts: {
     method: "predicateOnTab",

--- a/BeardedSpice/MediaStrategies/Pandora.js
+++ b/BeardedSpice/MediaStrategies/Pandora.js
@@ -7,11 +7,11 @@
 //  Modified by Anthony Whitaker on 12/13/16
 //
 BSStrategy = {
-  version:2,
-  displayName:"Pandora",
+  version: 2,
+  displayName: "Pandora",
   accepts: {
     method: "predicateOnTab",
-    format:"%K LIKE[c] '*pandora.com*'",
+    format: "%K LIKE[c] '*pandora.com*'",
     args: ["URL"]
   },
   isPlaying: function () {
@@ -21,19 +21,26 @@ BSStrategy = {
   toggle: function () {
     var e = document.querySelector('.playButton');
     var t = document.querySelector('.pauseButton');
-    if(t.style.display==='block') { t.click() }
+    if (t.style.display==='block') { t.click() }
     else { e.click() }
   },
-  next: function () { document.querySelector('.skipButton').click(); },
-  pause: function () { document.querySelector('.pauseButton').click(); },
-  favorite: function() { document.querySelector('.thumbUpButton').click(); },
+  next: function () {
+    document.querySelector('.skipButton').click();
+  },
+  pause: function () {
+    document.querySelector('.pauseButton').click();
+  },
+  favorite: function () {
+    document.querySelector('.thumbUpButton').click();
+  },
   trackInfo: function () {
     return {
       'track': document.querySelector('.playerBarSong').innerText,
       'artist': document.querySelector('.playerBarArtist').innerText,
       'album': document.querySelector('.playerBarAlbum').innerText,
       'image': document.querySelector('.playerBarArt').src,
-      'favorited': document.querySelector('.thumb').style.display === 'block' && document.querySelector('.thumb').id === 'thumbup'
+      'favorited': document.querySelector('.thumb').style.display === 'block' &&
+                   document.querySelector('.thumb').id === 'thumbup'
     };
   }
 }

--- a/BeardedSpice/MediaStrategies/Pandora.js
+++ b/BeardedSpice/MediaStrategies/Pandora.js
@@ -15,31 +15,70 @@ BSStrategy = {
     args: ["URL"]
   },
   isPlaying: function () {
-    return document.querySelector('.pauseButton').style.display === 'block';
+    if (document.querySelector('div.Tuner__Controls') !== null) {
+      return
+        document
+          .querySelector('.Tuner__Control__Play__Button')
+          .attributes['data-qa']
+          .value === 'play_button';
+    } else {
+      return document.querySelector('.pauseButton').style.display === 'block';
+    }
   },
   toggle: function () {
-    var playButton = document.querySelector('.playButton');
-    var pauseButton = document.querySelector('.pauseButton');
-    if (playButton.style.display==='block') { playButton.click() }
-    else { pauseButton.click() }
+    if (document.querySelector('div.Tuner__Controls') !== null) {
+      document.querySelector('.Tuner__Control__Play__Button').click();
+    } else {
+      var playButton = document.querySelector('.playButton');
+      var pauseButton = document.querySelector('.pauseButton');
+      if (playButton.style.display==='block') { playButton.click() }
+      else { pauseButton.click() }
+    }
   },
   next: function () {
+    document.querySelector('div.Tuner__Controls') !== null ?
+    document.querySelector('.Tuner__Control__Skip__Button').click() :
     document.querySelector('.skipButton').click();
   },
   pause: function () {
+    document.querySelector('div.Tuner__Controls') !== null ?
+    document.querySelector('.Tuner__Control__Play__Button').click() :
     document.querySelector('.pauseButton').click();
   },
   favorite: function () {
+    document.querySelector('div.Tuner__Controls') !== null ?
+    document.querySelector('.Tuner__Control__ThumbUp__Button').click() :
     document.querySelector('.thumbUpButton').click();
   },
   trackInfo: function () {
-    return {
-      'track': document.querySelector('.playerBarSong').innerText,
-      'artist': document.querySelector('.playerBarArtist').innerText,
-      'album': document.querySelector('.playerBarAlbum').innerText,
-      'image': document.querySelector('.playerBarArt').src,
-      'favorited': document.querySelector('.thumb').style.display === 'block' &&
-                   document.querySelector('.thumb').id === 'thumbup'
+    if (document.querySelector('div.Tuner__Controls') !== null) {
+      return {
+        'track': document
+                   .querySelector('div.Tuner__Audio__TrackDetail__title')
+                   .innerText,
+        'artist': document
+                    .querySelector('div.Tuner__Audio__TrackDetail__artist')
+                    .innerText,
+        'album': document
+                   .querySelector('.nowPlayingTopInfo__current__albumName')
+                   .innerText,
+        'image': document
+                   .querySelector('[data-qa=album_active_image]')
+                   .style['background-image']
+                   .slice(5, -2),
+        'favorited': document
+                       .querySelector('[data-qa=thumbs_up_button]')
+                       .classList.contains('ThumbUpButton--active')
+      };
+    } else {
+      return {
+        'track': document.querySelector('.playerBarSong').innerText,
+        'artist': document.querySelector('.playerBarArtist').innerText,
+        'album': document.querySelector('.playerBarAlbum').innerText,
+        'image': document.querySelector('.playerBarArt').src,
+        'favorited': document.querySelector('.thumb').style.display === 'block' &&
+                     document.querySelector('.thumb').id === 'thumbup'
+      };
     };
   }
 }

--- a/BeardedSpice/MediaStrategies/Pandora.js
+++ b/BeardedSpice/MediaStrategies/Pandora.js
@@ -15,8 +15,7 @@ BSStrategy = {
     args: ["URL"]
   },
   isPlaying: function () {
-    var t = document.querySelector('.pauseButton');
-    return (t.style.display === 'block');
+    return document.querySelector('.pauseButton').style.display === 'block';
   },
   toggle: function () {
     var e = document.querySelector('.playButton');

--- a/BeardedSpice/MediaStrategies/Pandora.js
+++ b/BeardedSpice/MediaStrategies/Pandora.js
@@ -76,8 +76,9 @@ BSStrategy = {
         'artist': document.querySelector('.playerBarArtist').innerText,
         'album': document.querySelector('.playerBarAlbum').innerText,
         'image': document.querySelector('.playerBarArt').src,
-        'favorited': document.querySelector('.thumb').style.display === 'block' &&
-                     document.querySelector('.thumb').id === 'thumbup'
+        'favorited': document
+                       .querySelector('div.thumbUpButton')
+                       .classList.contains('indicator')
       };
     };
   }

--- a/BeardedSpice/MediaStrategies/Pandora.js
+++ b/BeardedSpice/MediaStrategies/Pandora.js
@@ -18,10 +18,10 @@ BSStrategy = {
     return document.querySelector('.pauseButton').style.display === 'block';
   },
   toggle: function () {
-    var e = document.querySelector('.playButton');
-    var t = document.querySelector('.pauseButton');
-    if (t.style.display==='block') { t.click() }
-    else { e.click() }
+    var playButton = document.querySelector('.playButton');
+    var pauseButton = document.querySelector('.pauseButton');
+    if (playButton.style.display==='block') { playButton.click() }
+    else { pauseButton.click() }
   },
   next: function () {
     document.querySelector('.skipButton').click();

--- a/BeardedSpice/MediaStrategies/versions.plist
+++ b/BeardedSpice/MediaStrategies/versions.plist
@@ -99,7 +99,7 @@
 	<key>Overcast</key>
 	<integer>1</integer>
 	<key>Pandora</key>
-	<integer>2</integer>
+	<integer>3</integer>
 	<key>PlexWeb</key>
 	<integer>3</integer>
 	<key>PocketCasts</key>


### PR DESCRIPTION
Please see https://github.com/beardedspice/beardedspice/pull/545 for some previous discussion on this work.

Because of when things are evaluated (strategy load vs. web page context), it turns out to be pretty tricky to use additional functions as was proposed in my previous pull request. I determined that checking for the presence of `div.Tuner__Controls` reliably detects the new UI, so I used that since it's pretty concise.

I've tested this with both the old and new UIs. I think it makes sense to implement this in the existing strategy so that no one has to modify their BeardedSpice settings: they'll just get support for the new UI automatically, and BeardedSpice will work when they start to use the new UI instead of the old UI. If Pandora drops the old UI, we can simplify this strategy in the future.