### PR TITLE
Correct spelling of BSSC_ERROR_STRATEGY_NOTFOUND

### DIFF
--- a/BeardedSpice/BSCustomStrategyManager.m
+++ b/BeardedSpice/BSCustomStrategyManager.m
@@ -77,7 +77,7 @@ static BSCustomStrategyManager *singletonCustomStrategyManager;
             MediaStrategyRegistry *registry = [MediaStrategyRegistry singleton];
             error = [registry.strategyCache updateStrategyWithURL:pathToFile];
             
-            if (error.code == BSSC_ERROR_STARTEGY_NOTFOUND) {
+            if (error.code == BSSC_ERROR_STRATEGY_NOTFOUND) {
                 
                 BSMediaStrategy *newStrategy = [registry.strategyCache addStrategyWithURL:pathToFile];
                 if (newStrategy) {

--- a/BeardedSpice/BSStrategyCache.h
+++ b/BeardedSpice/BSStrategyCache.h
@@ -9,7 +9,7 @@
 @class BSMediaStrategy;
 
 extern NSString * _Nonnull BSStrategyCacheErrorDomain;
-#define BSSC_ERROR_STARTEGY_NOTFOUND            100
+#define BSSC_ERROR_STRATEGY_NOTFOUND            100
 
 @interface BSStrategyCache : NSObject
 

--- a/BeardedSpice/BSStrategyCache.m
+++ b/BeardedSpice/BSStrategyCache.m
@@ -67,7 +67,7 @@ NSString *BSMediaStrategyErrorDomain = @"BSMediaStrategyErrorDomain";
             }
         }
         else{
-            result = [NSError errorWithDomain:BSMediaStrategyErrorDomain code:BSSC_ERROR_STARTEGY_NOTFOUND userInfo:nil];
+            result = [NSError errorWithDomain:BSMediaStrategyErrorDomain code:BSSC_ERROR_STRATEGY_NOTFOUND userInfo:nil];
         }
     });
     
@@ -145,7 +145,7 @@ NSString *BSMediaStrategyErrorDomain = @"BSMediaStrategyErrorDomain";
 
         NSURL *filePath = [[NSURL alloc] initWithString:fileName relativeToURL:path];
         NSError *err = [self updateStrategyWithURL:filePath];
-        if (err.code == BSSC_ERROR_STARTEGY_NOTFOUND) {
+        if (err.code == BSSC_ERROR_STRATEGY_NOTFOUND) {
             [self addStrategyWithURL:filePath];
         };
     }

--- a/BeardedSpice/BSStrategyVersionManager.m
+++ b/BeardedSpice/BSStrategyVersionManager.m
@@ -158,7 +158,7 @@ NSString *BSVMStrategyChangedNotification = @"BSVMStrategyChangedNotification";
         return  YES;
     }
     
-    if (err.code == BSSC_ERROR_STARTEGY_NOTFOUND) {
+    if (err.code == BSSC_ERROR_STRATEGY_NOTFOUND) {
         
         BSMediaStrategy *newStrategy = [self.strategyCache addStrategyWithURL:pathToFile];
         if (newStrategy) {


### PR DESCRIPTION
Totally minor misspelling that wasn't breaking anything, but I noticed it when reading through the code.