### PR TITLE
Update Synology.js

### DIFF
--- a/BeardedSpice/MediaStrategies/Synology.js
+++ b/BeardedSpice/MediaStrategies/Synology.js
@@ -28,12 +28,16 @@ BSStrategy = {
     var albumArtist = document.querySelector('.info-album-artist span').innerText.split(' - ');
     var album = albumArtist[0];
     var artist = albumArtist.reverse();
-    // Image not used due to image resources can only be loaded by authenticated apps
-    // var albumArt = document.querySelector('.player-info-thumb').getAttribute('src');
+    var progress = document.querySelector('.syno-as-player-position-block').innerText;
+    /*
+    Image not used due to image resources can only be loaded by authenticated apps
+    var albumArt = document.querySelector('.player-info-thumb').getAttribute('src');
+    */
     return {
       'track': track,
       'artist': artist[0],
       'album': album,
+      'progress': progress
     };
   }
 }

--- a/BeardedSpice/MediaStrategies/Synology.js
+++ b/BeardedSpice/MediaStrategies/Synology.js
@@ -7,9 +7,10 @@ BSStrategy = {
   version: 2,
   displayName: "Synology Audio Station",
   accepts: {
-    method: "predicateOnTab",
-    format:"%K LIKE[c] '* - Audio Station*'",
-    args: ["title"]
+    method: "script",
+    script: function () {
+        return (baseURL == "webman/3rdparty/AudioStation");
+    }
   },
   isPlaying: function () {return ( (document.querySelector('.player-play span:not(.player-btn-pause)') ? false : true));},
   toggle: function () {document.querySelectorAll('.player-play button')[0].click()},

--- a/BeardedSpice/MediaStrategies/Synology.js
+++ b/BeardedSpice/MediaStrategies/Synology.js
@@ -1,23 +1,38 @@
 //
 //  Synology.plist
 //  BeardedSpice
-//
-//  Created by Stephan van Diepen on 16/01/2014.
-//  Copyright (c) 2013 Stephan van Diepen. All rights reserved.
+//  
 //
 BSStrategy = {
-  version:1,
-  displayName:"Synology Audio Station",
+  version: 2,
+  displayName: "Synology Audio Station",
   accepts: {
     method: "predicateOnTab",
-    format:"%K LIKE[c] '*synology.me*'",
-    args: ["URL"]
+    format:"%K LIKE[c] '* - Audio Station*'",
+    args: ["title"]
   },
-  isPlaying: function () {},
+  isPlaying: function () {return ( (document.querySelector('.player-play span:not(.player-btn-pause)') ? false : true));},
   toggle: function () {document.querySelectorAll('.player-play button')[0].click()},
   next: function () {document.querySelectorAll('.player-next button')[0].click()},
-  favorite: function () {},
   previous: function () {document.querySelectorAll('.player-prev button')[0].click()},
   pause: function () {document.querySelectorAll('.player-stop button')[0].click()},
-  trackInfo: function () {}
+  favorite: function () {},
+  /*
+  - Return a dictionary of namespaced key/values here.
+  All manipulation should be supported in javascript.
+  - Namespaced keys currently supported include: track, album, artist, favorited, image (URL)
+  */
+  trackInfo: function () {
+    var track = document.querySelector('.info-title span').innerText;
+    var albumArtist = document.querySelector('.info-album-artist span').innerText.split(' - ');
+    var album = albumArtist[0];
+    var artist = albumArtist.reverse();
+    // Image not used due to image resources can only be loaded by authenticated apps
+    // var albumArt = document.querySelector('.player-info-thumb').getAttribute('src');
+    return {
+      'track': track,
+      'artist': artist[0],
+      'album': album,
+    };
+  }
 }

--- a/BeardedSpice/MediaStrategies/versions.plist
+++ b/BeardedSpice/MediaStrategies/versions.plist
@@ -153,7 +153,7 @@
 	<key>Subsonic</key>
 	<integer>1</integer>
 	<key>Synology</key>
-	<integer>1</integer>
+	<integer>2</integer>
 	<key>TidalHiFi</key>
 	<integer>1</integer>
 	<key>TuneIn</key>


### PR DESCRIPTION
Tested on Audiostation version 6.0.2-3093. 
Security option "Improve security with HTTP Content Security Policy (CSP) header" must be turned OFF for BeardedSpice to control Audiostation. This setting can be found under Control Panel > Security
Audiostation access and control no longer limited to *.synology.me domains. This was accomplished by changing the predicateOnTab to detect page title pattern.
Added trackinfo. Artist isn't a unique field, rather the last item in a " - " separate list. We grab the last item in the list, however if an artist has a " - " in their name this will only return the last part of their name.
Synology Audiostation doesn't allow image to be loaded by non authenticated (non logged in) applications. So album covers aren't supported.