### PR TITLE
Use "StrategyName - SongTitle" in status menu items instead of the tab title

### DIFF
--- a/BeardedSpice/AppDelegate.m
+++ b/BeardedSpice/AppDelegate.m
@@ -756,8 +756,19 @@ BOOL accessibilityApiEnabled = NO;
     MediaStrategyRegistry *registry = [MediaStrategyRegistry singleton];
     BSMediaStrategy *strategy = [registry getMediaStrategyForTab:tab];
     if (strategy) {
+        // default title value
+        NSString *title = tab.title;
 
-        NSMenuItem *menuItem = [[NSMenuItem alloc] initWithTitle:[tab.title trimToLength:40] action:@selector(updateActiveTabFromMenuItem:) keyEquivalent:@""];
+        // try to set the current track's title as the menu item's title
+        BSTrack *trackInfo = [strategy trackInfo:tab];
+        if (trackInfo) {
+            NSString *trackTitle = trackInfo.track;
+            if ([trackTitle length] > 0) {
+                title = [NSString stringWithFormat:@"%@ - %@", [strategy displayName], trackTitle];
+            }
+        }
+
+        NSMenuItem *menuItem = [[NSMenuItem alloc] initWithTitle:[title trimToLength:40] action:@selector(updateActiveTabFromMenuItem:) keyEquivalent:@""];
         if (menuItem) {
             [menuItem setRepresentedObject:tab];
 


### PR DESCRIPTION
The current implementation, which uses a tab's title in the status menu,
works well for sites like soundcloud which update the tab's title according
to the currently playing song. But for sites that _don't_ update the title,
one can't know the current track title simply by looking at beardedspice's
menu. So, instead of using the tab title, we could use the aforementioned
format for the sites whose track info is available and fall back on the
tab title for other sites.

P.S.: The code may be a little amateurish since this is my first time writing in Obj-C. :)