### PR TITLE
Add Egghead.io media strategy

### DIFF
--- a/BeardedSpice/MediaStrategies/Eggheadio.js
+++ b/BeardedSpice/MediaStrategies/Eggheadio.js
@@ -1,0 +1,41 @@
+//
+//  Eggheadio.plist
+//  BeardedSpice
+//
+//  Created by Carlos Filoteo on 3/20/17.
+//  Copyright (c) 2017 GPL v3 http://www.gnu.org/licenses/gpl.html
+//
+BSStrategy = {
+  version:1,
+  displayName:"Eggheadio",
+  accepts: {
+    method: "predicateOnTab",
+    format:"%K LIKE[c] '*egghead.io/lessons*'",
+    args: ["URL"]
+  },
+  isPlaying:function () {
+    return Wistia.api("wistia_").state() === "playing";
+  },
+  toggle: function () {
+    var video = Wistia.api("wistia_");
+    video.state() === "playing" ? video.pause() : video.play();
+  },
+  previous: function () {
+    var e = document.querySelector(".up-next-list-item.current").parentElement.previousSibling;
+    if(e){ e.childNodes[0].click(); }
+  },
+  next: function () {
+    var e = document.querySelector(".up-next-list-item.current").parentElement.nextSibling;
+    if(e){ e.childNodes[1].click(); }
+  },
+  pause:function () {
+    Wistia.api("wistia_").pause();
+  },
+  trackInfo: function () {
+    return {
+      "track": document.querySelector("meta[itemprop=name]").getAttribute("content"),
+      "artist": window.instructor,
+      "image": document.querySelector("meta[itemprop=image]").getAttribute("content")
+    }
+  }
+}

--- a/BeardedSpice/MediaStrategies/Eggheadio.js
+++ b/BeardedSpice/MediaStrategies/Eggheadio.js
@@ -1,5 +1,5 @@
 //
-//  Eggheadio.plist
+//  Eggheadio.js
 //  BeardedSpice
 //
 //  Created by Carlos Filoteo on 3/20/17.
@@ -7,7 +7,7 @@
 //
 BSStrategy = {
   version:1,
-  displayName:"Eggheadio",
+  displayName:"Egghead.io",
   accepts: {
     method: "predicateOnTab",
     format:"%K LIKE[c] '*egghead.io/lessons*'",

--- a/BeardedSpice/MediaStrategies/versions.plist
+++ b/BeardedSpice/MediaStrategies/versions.plist
@@ -42,6 +42,8 @@
 	<integer>2</integer>
 	<key>DigitallyImported</key>
 	<integer>1</integer>
+	<key>Eggheadio</key>
+	<integer>1</integer>
 	<key>EightTracks</key>
 	<integer>1</integer>
 	<key>Fip</key>


### PR DESCRIPTION
#421 went unattended for a long time. Lots has changed and it looks like its much easier to get stuff working now. This PR adds a media strategy for Egghead.io. I've only tested this by importing the js file to BeardedSpice and everything works correctly. 