### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/docs/developers-guide-web.md
+++ b/docs/developers-guide-web.md
@@ -1,5 +1,5 @@
 
-#Developers' Guide for Website Strategies
+# Developers' Guide for Website Strategies
 
 ## Dependencies
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
