### PR TITLE
Pandora: fix pause function in new UI

### DIFF
--- a/BeardedSpice/MediaStrategies/Pandora.js
+++ b/BeardedSpice/MediaStrategies/Pandora.js
@@ -5,10 +5,11 @@
 //  Created by Jose Falcon on 2013-12-16
 //  Updated by Anthony Whitaker on 2016-12-13
 //  Support for new UI added by Bret Martin on 2017-01-01
+//  Fix pause function in new UI by Andrew Ray on 2017-04-28
 //  Copyright (c) 2013-2017 GPL v3 http://www.gnu.org/licenses/gpl.html
 //
 BSStrategy = {
-  version: 3,
+  version: 4,
   displayName: "Pandora",
   accepts: {
     method: "predicateOnTab",
@@ -42,9 +43,13 @@ BSStrategy = {
     document.querySelector('.skipButton').click();
   },
   pause: function () {
-    document.querySelector('div.Tuner__Controls') !== null ?
-    document.querySelector('.Tuner__Control__Play__Button').click() :
-    document.querySelector('.pauseButton').click();
+    if(document.querySelector('div.Tuner__Controls') !== null) {
+      var playPauseButton = document.querySelector('.Tuner__Control__Play__Button');
+      if (playPauseButton.attributes['data-qa'].value === 'pause_button') {
+        playPauseButton.click()
+      }
+    } else {
+    document.querySelector('.pauseButton').click();}
   },
   favorite: function () {
     document.querySelector('div.Tuner__Controls') !== null ?

--- a/BeardedSpice/MediaStrategies/versions.plist
+++ b/BeardedSpice/MediaStrategies/versions.plist
@@ -113,7 +113,7 @@
 	<key>Pakartot</key>
 	<integer>1</integer>
 	<key>Pandora</key>
-	<integer>3</integer>
+	<integer>4</integer>
 	<key>PhishIn</key>
 	<integer>1</integer>
 	<key>PhishTracks</key>


### PR DESCRIPTION
Currently with the Pandora new UI the pause function unconditionally clicks the play/pause button. This can lead to odd things like issue #336 and starting playback when headphones are unplugged. This patch checks to see if the button is in fact the pause button, using the same logic as other functions use, before clicking it.