### PR TITLE
BBC Radio Programmes Support

### DIFF
--- a/BeardedSpice/MediaStrategies/BBCRadioProgrammes.bsstrategy
+++ b/BeardedSpice/MediaStrategies/BBCRadioProgrammes.bsstrategy
@@ -3,11 +3,8 @@
 //  BeardedSpice
 //
 //  Created by Ben Pollman on 05/16/17.
-//  Copyright (c) 2015 Ben Pollman. All rights reserved.
+//  Copyright (c) 2017 Ben Pollman. All rights reserved.
 //
-// strategy/site notes
-// - previous and next available on site but not implemented by script
-// - favorite available on site but not implemented
 BSStrategy = {
   version:1,
   displayName:"BBC Radio Programmes",

--- a/BeardedSpice/MediaStrategies/BBCRadioProgrammes.bsstrategy
+++ b/BeardedSpice/MediaStrategies/BBCRadioProgrammes.bsstrategy
@@ -1,0 +1,66 @@
+//
+//  BBCRadio.plist
+//  BeardedSpice
+//
+//  Created by Ben Pollman on 05/16/17.
+//  Copyright (c) 2015 Ben Pollman. All rights reserved.
+//
+// strategy/site notes
+// - previous and next available on site but not implemented by script
+// - favorite available on site but not implemented
+BSStrategy = {
+  version:1,
+  displayName:"BBC Radio Programmes",
+  accepts: {
+    method: "predicateOnTab",
+    format:"%K LIKE[c] '*bbc.co.uk/programmes/*'",
+    args: ["URL"]
+  },
+  isPlaying:function () {
+  	let iframe = window.parent.document.querySelector('iframe[id^="smphtml5iframeepisode-playout-"]');
+  	
+  	if (iframe == null) {
+  		return
+  	}
+    let pause = iframe.contentDocument.querySelector('.p_pauseButton');
+    
+    return pause != null;
+    
+  },
+  toggle:function () {
+  
+  	let iframe = window.parent.document.querySelector('iframe[id^="smphtml5iframeepisode-playout-"]');
+  
+    let play = iframe.contentDocument.querySelector('.p_playButton');
+    let pause = iframe.contentDocument.querySelector('.p_pauseButton');
+   
+    if (play != null) {
+      play.click();
+    } else if (pause != null) {
+      pause.click();
+    }
+  },
+  next: function () {},
+  favorite: function () {},
+  previous: function () {},
+  pause: function () {
+  	let iframe = window.parent.document.querySelector('iframe[id^="smphtml5iframeepisode-playout-"]');
+    let pause = iframe.contentDocument.querySelector('.p_pauseButton').click();
+    },
+  trackInfo: function () {
+  	  let iframe = window.parent.document.querySelector('iframe[id^="smphtml5iframeepisode-playout-"]');
+  	
+  	  let imagediv = iframe.contentDocument.querySelector('#mediaContainer');
+  	  let titlediv = window.parent.document.querySelector('div.br-masthead__title > a');
+  	  let artistdiv = window.parent.document.querySelector("div.island > div > h1[property='name']");
+  	
+  	console.log(imagediv.style);
+  	console.log(titlediv.text);
+  	console.log(artistdiv.innerText);
+  	
+    return {'image': imagediv ? imagediv.style.backgroundImage : null,
+            'track': titlediv ? titlediv.text : null,
+            'artist': artistdiv ? artistdiv.innerText : null
+    };
+  }
+}

--- a/BeardedSpice/MediaStrategies/BBCRadioProgrammes.bsstrategy
+++ b/BeardedSpice/MediaStrategies/BBCRadioProgrammes.bsstrategy
@@ -1,5 +1,5 @@
 //
-//  BBCRadio.plist
+//  BBCRadioProgrammes.plist
 //  BeardedSpice
 //
 //  Created by Ben Pollman on 05/16/17.
@@ -16,51 +16,60 @@ BSStrategy = {
     format:"%K LIKE[c] '*bbc.co.uk/programmes/*'",
     args: ["URL"]
   },
-  isPlaying:function () {
+
+  isPlaying: function () {
   	let iframe = window.parent.document.querySelector('iframe[id^="smphtml5iframeepisode-playout-"]');
-  	
-  	if (iframe == null) {
-  		return
-  	}
-    let pause = iframe.contentDocument.querySelector('.p_pauseButton');
-    
-    return pause != null;
-    
+    return (iframe != null) && (iframe.contentDocument.querySelector('.p_pauseButton') != null);
   },
-  toggle:function () {
-  
+
+  toggle: function () {
   	let iframe = window.parent.document.querySelector('iframe[id^="smphtml5iframeepisode-playout-"]');
   
-    let play = iframe.contentDocument.querySelector('.p_playButton');
-    let pause = iframe.contentDocument.querySelector('.p_pauseButton');
-   
-    if (play != null) {
-      play.click();
-    } else if (pause != null) {
-      pause.click();
+    if (iframe != null) {
+      let play = iframe.contentDocument.querySelector('.p_playButton');
+      let pause = iframe.contentDocument.querySelector('.p_pauseButton');
+     
+      if (play != null) {
+        play.click();
+      } 
+      else if (pause != null) {
+        pause.click();
+      }
     }
   },
-  next: function () {},
-  favorite: function () {},
-  previous: function () {},
+
+  previous: function () { window.parent.document.querySelector('.istats--more-panel-play-previous a').click(); },
+  next: function () { window.parent.document.querySelector('.istats--more-panel-play-next a').click(); },
   pause: function () {
   	let iframe = window.parent.document.querySelector('iframe[id^="smphtml5iframeepisode-playout-"]');
-    let pause = iframe.contentDocument.querySelector('.p_pauseButton').click();
-    },
+
+    if (iframe != null) {
+      let pause = iframe.contentDocument.querySelector('.p_pauseButton');
+      if (pause != null) {
+        pause.click();
+      }
+    }
+  },
+
+  favorite: function () { window.parent.document.querySelector('#pf1').click(); },
+
   trackInfo: function () {
-  	  let iframe = window.parent.document.querySelector('iframe[id^="smphtml5iframeepisode-playout-"]');
+    let trackdiv = window.parent.document.querySelector('div.br-masthead__title > a');
+    let artistdiv = window.parent.document.querySelector("div.island > div > h1[property='name']");
+    let albumdiv = window.parent.document.querySelector('.service-brand-logo-master');
+    let favoritediv = window.parent.document.querySelector('#pf1');
+
+    let iframe = window.parent.document.querySelector('iframe[id^="smphtml5iframeepisode-playout-"]');
+    let imagediv = iframe != null ? iframe.contentDocument.querySelector('#mediaContainer') : null;
+    let timediv = iframe != null ? iframe.contentDocument.querySelector('.p_timeDisplay') : null;
   	
-  	  let imagediv = iframe.contentDocument.querySelector('#mediaContainer');
-  	  let titlediv = window.parent.document.querySelector('div.br-masthead__title > a');
-  	  let artistdiv = window.parent.document.querySelector("div.island > div > h1[property='name']");
-  	
-  	console.log(imagediv.style);
-  	console.log(titlediv.text);
-  	console.log(artistdiv.innerText);
-  	
-    return {'image': imagediv ? imagediv.style.backgroundImage : null,
-            'track': titlediv ? titlediv.text : null,
-            'artist': artistdiv ? artistdiv.innerText : null
+    return {
+      'track': trackdiv ? trackdiv.text : null,
+      'artist': artistdiv ? artistdiv.innerText : null,
+      'album' : albumdiv ? albumdiv.innerText : null,
+      'image': imagediv ? imagediv.style.backgroundImage : null,
+      'favorited': favoritediv ? favoritediv.classList.contains("p-f-added") : false,
+      'progress': timediv ? timediv.innerText.replace("/", " / ") : "- / -"
     };
   }
 }

--- a/BeardedSpice/MediaStrategies/versions.plist
+++ b/BeardedSpice/MediaStrategies/versions.plist
@@ -18,6 +18,8 @@
 	<integer>2</integer>
 	<key>BBCRadio</key>
 	<integer>1</integer>
+	<key>BBCRadioProgrammes</key>
+	<integer>1</integer>
 	<key>BE-AT.TV</key>
 	<integer>1</integer>
 	<key>Beatguide</key>


### PR DESCRIPTION
Support for BBC's programmes site (http://www.bbc.co.uk/programmes) which is totally different than the live streaming iplayer site (http://bbc.co.uk/radio/player/)

Supports all beardedspice media strategy options and tested with several links on the site.