### PR TITLE
Adding uninstall.sh script

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -8,6 +8,7 @@ sudo rm -rf ~/Library/Application\ Support/BeardedSpice
 sudo rm -rf /Applications/BeardedSpice.app
 
 # Reboot the notifications service so it realizes that the app is gone
-sudo killall usernoted
+launchctl stop com.apple.usernoted
+launchctl start com.apple.usernoted
 
 echo \# BeardedSpice has been uninstalled

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# clean up the previous installation so we can test it again.
+
+killall BeardedSpice
+# Remove files
+sudo rm -f ~/Library/Preferences/com.beardedspice.BeardedSpice.plist
+sudo rm -rf ~/Library/Application\ Support/BeardedSpice
+sudo rm -rf /Applications/BeardedSpice.app
+
+# Reboot the notifications service so it realizes that the app is gone
+sudo killall usernoted
+
+echo \# BeardedSpice has been uninstalled


### PR DESCRIPTION
Should fix #627 

Removes all the associated files and restarts the notification center so that bearded spice gets removed from it. Should probably be updated in the future to a more robust method of finding the app. Wasn't sure if anything should be added to the readme or not, but it can be run with `sudo ./uninstall.sh`