### PR TITLE
Add madsonic strategy

### DIFF
--- a/BeardedSpice/MediaStrategies/Madsonic.js
+++ b/BeardedSpice/MediaStrategies/Madsonic.js
@@ -1,0 +1,56 @@
+//
+//  Madsonic.js
+//  BeardedSpice
+//
+//  Created by Matt Behrens on 2017/05/20
+//  Copyright (c) 2016 GPL v3 http://www.gnu.org/licenses/gpl.html
+//
+//  Tested with:
+//  v1 - Madsonic 6.2.9080
+//
+BSStrategy = {
+    version:1,
+    displayName:"Madsonic",
+    accepts: {
+        method: "predicateOnTab",
+        format:"%K LIKE[c] '*Madsonic*'",
+        args: ["title"]
+    },
+
+    isPlaying: function () {
+        var is_playing = parent.frames.playQueue.document.querySelector('#startButton').style.display === "none";
+        return is_playing;
+    },
+
+    toggle:function () {
+        var is_playing = parent.frames.playQueue.document.querySelector('#startButton').style.display === "none";
+        if (is_playing) {
+            parent.frames.playQueue.document.querySelector('#stopButton').click();
+        } else {
+            parent.frames.playQueue.document.querySelector('#startButton').click();
+        }
+    },
+
+    next:function () {
+        parent.frames.playQueue.document.querySelector('#nextButton').click();
+    },
+    favorite: function () {
+        parent.frames.playQueue.document.querySelector('#starred_off').click();
+    },
+    previous:function () {
+        parent.frames.playQueue.document.querySelector('#previousButton').click();
+    },
+    pause:function () {
+        parent.frames.playQueue.document.querySelector('#stopButton').click();
+    },
+
+    trackInfo: function () {
+        frame = parent.frames.playQueue;
+        return {
+            'track': frame.document.querySelector('#songName').innerText,
+            'artist': frame.document.querySelector('#artistName').textContent,
+            'favorited': frame.parent.frames.playQueue.document.querySelector('#starred_on').style.display === "none",
+            'image': frame.document.querySelector('#coverArt').src,
+        };
+    }
+}

--- a/BeardedSpice/MediaStrategies/versions.plist
+++ b/BeardedSpice/MediaStrategies/versions.plist
@@ -88,6 +88,8 @@
 	<integer>1</integer>
 	<key>Lynda</key>
 	<integer>1</integer>
+	<key>Madsonic</key>
+	<integer>1</integer>
 	<key>MixCloud</key>
 	<integer>3</integer>
 	<key>MusicForProgramming</key>


### PR DESCRIPTION
I think I'm moving to Madsonic as my favorite player over Plex/Subsonic. 

Here's a strategy that is working for me locally with the latest Madsonic version, Madsonic 6.2.9080. I wish I could do it more in JS instead of DOM attr checking, but the code is pretty foreign to me.

Here's a screenshot showing the Track Info notification settings correctly working: https://files.asktherelic.com/Screen_Shot_2017-05-20_at_1.31.53_PM.png

