### PR TITLE
Update developers guide

### DIFF
--- a/docs/developers-guide-web.md
+++ b/docs/developers-guide-web.md
@@ -87,6 +87,11 @@ Update the [`versions.plist`](https://github.com/beardedspice/beardedspice/blob/
     <integer>1</integer>
 ```
 
+Finally, add it to the list in [`README.md`](https://github.com/beardedspice/beardedspice/blob/master/README.md) in alphabetical order:
+```markdown
+- [Amazon Music](https://www.amazon.com/gp/dmusic/cloudplayer/player)
+```
+
 ## Updating a *Media Strategy*
 
 In the case that a strategy template no longer works with a service, or is missing functionality: All logic for controlling a service should be written in javascript and stored in the appropriate .js file. For example, the [Youtube strategy](https://github.com/beardedspice/beardedspice/blob/master/BeardedSpice/MediaStrategies/Youtube.js) has javascript for all five functions as well as partial trackInfo retrieval.


### PR DESCRIPTION
Reminds strategy makers to add their strategy to the list in `README.md`. See the [discussion on #667](https://github.com/beardedspice/beardedspice/pull/667#issuecomment-306065806). This does not include updating `beardedspice.github.io` in [this list](https://github.com/beardedspice/beardedspice.github.io/blob/77f870b0e30f6392c2c5467319c32050f82b4740/index.html#L72) because that would require a separate PR for each strategy. I cannot think of a good solution to this other than having a bot update that list (or by using Javascript on the website).