### PR TITLE
Add partial DatPiff support

### DIFF
--- a/BeardedSpice/MediaStrategies/DatPiff.js
+++ b/BeardedSpice/MediaStrategies/DatPiff.js
@@ -1,0 +1,47 @@
+//
+//  DatPiff.js
+//  BeardedSpice
+//
+//  Created by Beau on 2017-07-08
+//  Copyright (c) 2015-2017 GPL v3 http://www.gnu.org/licenses/gpl.html
+//
+
+// We put the copyright inside the plist to retain consistent syntax coloring.
+
+// Use a syntax checker to ensure validity. One is provided by nodejs (`node -c filename.js`)
+// Normal formatting is supported (can copy/paste with newlines and indentations)
+
+// Caveats:
+// This only works on the desktop version of DatPiff, with Flash disabled.
+// Since that loads an iframe on a different domain, we need the bare iframe loaded in a tab.
+
+BSStrategy = {
+  version: 1,
+  displayName: "DatPiff",
+  accepts: {
+    method: "predicateOnTab",
+    format: "%K LIKE[c] '*mobile.datpiff.com/social/twitter/twitter-card.php*'",
+    args: ["URL"],
+  },
+
+  isPlaying: function () {return document.querySelector('.isplay') !== null;},
+  toggle:    function () {return document.querySelector('.play').click();},
+  previous:  function () {return document.querySelector('.back').click();},
+  next:      function () {return document.querySelector('.next').click();},
+  pause:     function () {
+      var isplay = document.querySelector('.isplay');
+      if (isplay !== null) {
+          isplay.click();
+      }
+  },
+  favorite:  function () {},
+  trackInfo: function () {
+    return {
+        'track': document.querySelector('.main-playing').innerText,
+        'album': document.querySelector('.title').innerText,
+        'artist': document.querySelector('.artist').innerText,
+        'image': document.querySelector('div:nth-child(2) img').src,
+    };
+  }
+};
+// The file must have an empty line at the end.

--- a/BeardedSpice/MediaStrategies/versions.plist
+++ b/BeardedSpice/MediaStrategies/versions.plist
@@ -40,6 +40,8 @@
 	<integer>1</integer>
 	<key>CozyCloud</key>
 	<integer>1</integer>
+	<key>DatPiff</key>
+	<integer>1</integer>
 	<key>Deezer</key>
 	<integer>3</integer>
 	<key>DigitallyImported</key>

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ From the preferences tab, uncheck any types of webpages that you don't want Bear
 - [Composed](https://www.composed.com/)
 - [Cozy Cloud](https://cozy.io/en/) ([cozy-music](https://github.com/cozy-labs/cozy-music) application)
 - [Dailymotion](https://www.dailymotion.com)
+- [DatPiff](http://www.datpiff.com/)
 - [Deezer](http://deezer.com)
 - [Digitally Imported](http://www.di.fm/)
 - [focus@will](https://www.focusatwill.com)


### PR DESCRIPTION
Hi,

This adds partial support for DatPiff (http://www.datpiff.com/).

It works on the desktop version of the site, with Flash disabled (important). However, that works by loading an iframe from a separate domain, which we can't (unless I'm mistaken—it's a browser security thing) interact with. So you need to load the iframe yourself in a separate tab.

So, instead of http://www.datpiff.com/pop-mixtape-player-2014.2.php?mediaid=m54d0008&trackid=, you'll need to inspect element, and open the iframe in a different tab https://mobile.datpiff.com/social/twitter/twitter-card.php?mediaid=472141. Then it works.

Let me know if you'd like me to amend anything. Big fan of BeardedSpice here!