### PR TITLE
Add strategy for controlling the web interface of HTTPMS

### DIFF
--- a/BeardedSpice/MediaStrategies/httpms.js
+++ b/BeardedSpice/MediaStrategies/httpms.js
@@ -1,0 +1,48 @@
+// Bearded spice strategy for the web interface of HTTPMS.
+// What is bearded spice you ask? https://github.com/beardedspice/beardedspice
+// What about HTTPMS? https://github.com/ironsmile/httpms
+
+BSStrategy = {
+  version: 1,
+  displayName: "HTTPMS",
+  accepts: {
+    method: "predicateOnTab",
+    format: "%K LIKE[c] '*HTTPMS'",
+    args: ["title"]
+  },
+
+  isPlaying: function () { return document.title.match(/.*\| HTTPMS$/) != null; },
+  toggle:    function () {
+    var playing = (document.title.match(/.*\| HTTPMS$/) != null);
+    if (playing) {
+      document.querySelector('.jp-pause').click();
+    } else {
+      document.querySelector('.jp-play').click();
+    }
+  },
+  previous:  function () { document.querySelector('.jp-previous').click(); },
+  next:      function () { document.querySelector('.jp-next').click(); },
+  pause:     function () { document.querySelector('.jp-pause').click(); },
+  favorite:  function () { /* there is no favourite feature in this player */ },
+
+  trackInfo: function () {
+    var selected = document.querySelector('a.jp-playlist-current');
+    var artist = document.querySelector('a.jp-playlist-current > .jp-artist').innerText.slice(3);
+    var trackNumberedText = selected.innerText;
+    var album = document.querySelector('li.jp-playlist-current').children[0].children[1].children[0].innerText;
+    var m = trackNumberedText.match(/\d+\.\s+(.+) by/);
+
+    if (m) {
+      track = m[1];
+    } else {
+      track = trackNumberedText;
+    }
+
+    return {
+        'track': track,
+        'album': album,
+        'artist': artist,
+        'favorited': false
+    };
+  }
+}

--- a/BeardedSpice/MediaStrategies/versions.plist
+++ b/BeardedSpice/MediaStrategies/versions.plist
@@ -64,6 +64,8 @@
 	<integer>1</integer>
 	<key>HotNewHipHop</key>
 	<integer>1</integer>
+	<key>HTTPMS</key>
+	<integer>1</integer>
 	<key>Hungama</key>
 	<integer>1</integer>
 	<key>HypeMachine</key>

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ From the preferences tab, uncheck any types of webpages that you don't want Bear
 - [Google Music](https://play.google.com/music/)
 - [GrooveShark](http://grooveshark.com)
 - [HotNewHipHop Mixtapes](http://www.hotnewhiphop.com/mixtapes/)
+- [HTTPMS](https://github.com/ironsmile/httpms)
 - [HypeMachine](http://hypem.com)
 - [iHeart Radio](http://www.iheart.com/)
 - [IndieShuffle](http://www.indieshuffle.com)


### PR DESCRIPTION
[HTTPMS](https://github.com/ironsmile/httpms) is short for "HTTP Media Server". This is a small media server with REST interface I've created.

Not much left to say. As far as I can tell the strategy works well. The only thing not implemented is adding to favorites. This does not make sense for HTTPMS since there is no such a feature. Also, at the moment there is no track/album/artist image support so the key in `trackInfo` is left undefined.