### PR TITLE
Add favorited track info to GoogleMusic strategy

### DIFF
--- a/BeardedSpice/MediaStrategies/GoogleMusic.js
+++ b/BeardedSpice/MediaStrategies/GoogleMusic.js
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Tyler Rhodes / Jose Falcon. All rights reserved.
 //
 BSStrategy = {
-  version:2,
+  version:3,
   displayName:"GoogleMusic",
   accepts: {
     method: "predicateOnTab",
@@ -32,6 +32,7 @@ BSStrategy = {
       'track':  document.getElementById('currently-playing-title').innerText,
       'album':  document.getElementsByClassName('player-album')[0].innerText,
       'artist': document.getElementById('player-artist').innerText,
+      'favorited': !document.querySelector('#playerSongInfo paper-icon-button[icon="sj:thumb-up-outline"] svg.iron-icon > g').transform.baseVal.length,
       'image':  document.getElementById('playerBarArt').getAttribute('src')
     }
   }

--- a/BeardedSpice/MediaStrategies/versions.plist
+++ b/BeardedSpice/MediaStrategies/versions.plist
@@ -59,7 +59,7 @@
 	<key>GenieMusic</key>
 	<integer>1</integer>
 	<key>GoogleMusic</key>
-	<integer>2</integer>
+	<integer>3</integer>
 	<key>GrooveShark</key>
 	<integer>1</integer>
 	<key>HotNewHipHop</key>


### PR DESCRIPTION
The selector looks a bit nasty, but it's the only way I figured. To indicate that the track is favorited, Google replaces contents of icon's SVG.

P.S. I'm not feeling confident with setting up XCode and stuff, so any help regarding testing this change will be helpful 🙂 
P.P.S. The former includes throwing at me some guide "for dummies" so I could test it myself.