### PR TITLE
Added MediaStrategy for 99fm

### DIFF
--- a/BeardedSpice/MediaStrategies/99fm.js
+++ b/BeardedSpice/MediaStrategies/99fm.js
@@ -1,0 +1,29 @@
+//
+//  99fm
+//  BeardedSpice
+//
+//  Created by Roy Sommer on 01/08/18.
+//  Copyright (c) 2018 GPL v3 http://www.gnu.org/licenses/gpl.html
+//
+BSStrategy = {
+  version: 1,
+  displayName: "99fm",
+  accepts: {
+    method: "predicateOnTab",
+    format: "%K LIKE[c] '*eco99fm.maariv.co.il/music_channel/*'",
+    args: ["URL"]
+  },
+  isPlaying: function () { return !document.querySelector('video.vjs-tech').paused; },
+  toggle: function () { document.querySelector('button.vjs-play-control').click(); },
+  previous: function () { document.querySelector('video.vjs-tech').currentTime -= 30; },
+  next: function () { document.querySelector('video.vjs-tech').currentTime += 30; },
+  pause: function () { document.querySelector('video.vjs-tech').pause(); },
+  trackInfo: function () {
+    return {
+      'image': 'http://eco99fm.maariv.co.il' + document.querySelector('.vjs-poster').style.backgroundImage.replace('url("', '').replace('")', ''),
+      'track': document.querySelector('.newtopSetTitle').innerText,
+      'artist': '99fm',
+      'progress': document.querySelector('.vjs-current-time').innerText.replace('Current Time ', '').trim() + ' / ' + document.querySelector('.vjs-duration-display').innerText.replace('Duration Time ', '').trim()
+    };
+  }
+}

--- a/BeardedSpice/MediaStrategies/versions.plist
+++ b/BeardedSpice/MediaStrategies/versions.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>99fm</key>
+	<integer>1</integer>
 	<key>AmazonMusic</key>
 	<integer>1</integer>
 	<key>Anghami</key>


### PR DESCRIPTION
Added MediaStrategy for the Israeli website 99fm (eco99fm.maariv.co.il), which is in the added file `99fm.js`.

Added the strategy to the listings in `versions.plist`.

Since this site serves playlists and not individual tracks, the "next\previous track" buttons actually move the current time forwards and backwards in 30 seconds interval.

Would love a review, thanks :)