### PR TITLE
feat($strategies): implement PocketCasts beta strategy

### DIFF
--- a/BeardedSpice/MediaStrategies/PocketCasts.js
+++ b/BeardedSpice/MediaStrategies/PocketCasts.js
@@ -6,22 +6,46 @@
 //  Copyright (c) 2015 Tyler Rhodes / Jose Falcon. All rights reserved.
 //
 BSStrategy = {
-  version:1,
+  version:2,
   displayName:"PocketCasts",
   accepts: {
     method: "predicateOnTab",
-    format:"%K LIKE[c] '*play.pocketcasts.com*'",
+    format:"%K LIKE[c] '*play*.pocketcasts.com*'",
     args: ["URL"]
   },
-  toggle: function () {document.querySelector('div.play_pause_button').click()},
-  next: function () {document.querySelector('div.skip_forward_button').click()},
-  previous: function () {document.querySelector('div.skip_back_button').click()},
-  pause: function () {document.querySelector('div.pause_button').click()},
+  toggle: function () {document.querySelector('.play_pause_button').click()},
+  next: function () {document.querySelector('.skip_forward_button').click()},
+  previous: function () {document.querySelector('.skip_back_button').click()},
+  pause: function () {
+    document.querySelector(
+      '.play_pause_button'
+    ).classList.contains('pause_button')
+      ? document.querySelector('.play_pause_button').click()
+      : []
+  },
+  isPlaying: function () {
+    return document.querySelector('.play_pause_button').classList.contains('pause_button')
+  },
   trackInfo: function () {
     return {
-      'track': document.querySelector('div.player_top div.player_episode').innerText,
-      'album': document.querySelector('div.player_top div.player_podcast_title').innerText,
-      'image': document.querySelector('div.player_top div.player_artwork img').src,
+      'track': document.querySelector(
+        'div.player_top div.player_episode'
+      ) ? document.querySelector(
+        'div.player_top div.player_episode'
+      ).innerText : document.querySelector('.controls .episode-title').innerText,
+
+      'album': document.querySelector(
+        'div.player_podcast_title div.player_episode'
+      ) ? document.querySelector(
+        'div.player_podcast_title div.player_episode'
+      ).innerText : document.querySelector('.controls .podcast-title').innerText,
+
+      'image': document.querySelector(
+        'div.player_top div.player_artwork img'
+      ) ? document.querySelector(
+        'div.player_top div.player_artwork img'
+      ).src : document.querySelector('.controls .podcast-image img').src,
     };
   }
 }
+

--- a/BeardedSpice/MediaStrategies/versions.plist
+++ b/BeardedSpice/MediaStrategies/versions.plist
@@ -131,7 +131,7 @@
 	<key>PlexWeb</key>
 	<integer>3</integer>
 	<key>PocketCasts</key>
-	<integer>1</integer>
+	<integer>2</integer>
 	<key>PoolsideFM</key>
 	<integer>1</integer>
 	<key>ProductHunt</key>


### PR DESCRIPTION
This PR will: 

- Fix #759 
- Allow both current & beta PocketCasts players by adding a wildcard to the URL matcher
- Refactor old JS a bit to support both players (they actually do not differ too much in markup, just small HTML tags changes)

One problem, though, is the fact that I'm not able to get the track info to work at all 🙁 At the JS side I did everything just like in other media strategies, would love some help in getting this fixed, thanks!