### PR TITLE
Update SiriusXM.js

### DIFF
--- a/BeardedSpice/MediaStrategies/SiriusXM.js
+++ b/BeardedSpice/MediaStrategies/SiriusXM.js
@@ -3,11 +3,13 @@
 //  BeardedSpice
 //
 //  Created by Amit Chaudhari on 8/17/2017.
+//  Updated by Mathew Peterson on 04/05/2018
+//
 //  Copyright (c) 2017 GPL v3 http://www.gnu.org/licenses/gpl.html
 //
 
 BSStrategy = {
-  version: 1,
+  version: 2,
   displayName: "SiriusXM",
   accepts: {
     method: "predicateOnTab",
@@ -20,14 +22,13 @@ BSStrategy = {
   previous:  function () {$('.prev span').click();},
   next:      function () {$('.next span').click();},
   pause:     function () {if($('.play span').hasClass('RegularPause')) $('play span').click();},
-  favorite:  function () {$('div.content-type-header--right > button.fav-icon').click();},
+  favorite:  function () {$('div.fav-icon > button').click();},
 
   trackInfo: function () {
     return {
-        'track': $('div.line-two h2')[1].innerText,
-        'album': $('div.line-two h2')[0].innerText,
-        'artist': $('div.now-playing-channel-info button h1')[0].innerText,
-        'favorited': $('div.content-type-header--right > button.fav-icon').hasClass('RegularFav_B')
+        'artist': $('h1.np-track-artist').text().split("-")[0],
+        'track': $('h1.np-track-artist').text().split("-")[1],
+        'image': $("#fallbackImg").attr("src")
     };
   }
 }


### PR DESCRIPTION
Updates SiriusXM MediaStrategy for new web player. 

Currently, the web player does not share which album the track is on. It is also not possible to "favorite" a track, only a station.