### PR TITLE
Updated Youtube play/next/previous

### DIFF
--- a/BeardedSpice/MediaStrategies/Youtube.js
+++ b/BeardedSpice/MediaStrategies/Youtube.js
@@ -17,9 +17,9 @@ BSStrategy = {
   },
   isPlaying: function () { return !document.querySelector('#movie_player video').paused; },
   toggle: function () { document.querySelector('#movie_player .ytp-play-button').click(); },
-  previous: function () { document.querySelector('yt-player-manager').player_.previousVideo(); },
-  next: function () { document.querySelector('yt-player-manager').player_.nextVideo(); },
-  pause: function () { document.querySelector('yt-player-manager').player_.pauseVideo(); },
+  previous: function () { document.querySelector('#movie_player').previousVideo(); },
+  next: function () { document.querySelector('#movie_player').nextVideo(); },
+  pause: function () { document.querySelector('#movie_player').pauseVideo(); },
   favorite: function () { document.querySelector('ytd-toggle-button-renderer').click(); },
   trackInfo: function () {
     function pad(number) {

--- a/BeardedSpice/MediaStrategies/Youtube.js
+++ b/BeardedSpice/MediaStrategies/Youtube.js
@@ -8,7 +8,7 @@
 //
 
 BSStrategy = {
-  version: 2,
+  version: 3,
   displayName: "Youtube",
   accepts: {
     method: "predicateOnTab",

--- a/BeardedSpice/MediaStrategies/versions.plist
+++ b/BeardedSpice/MediaStrategies/versions.plist
@@ -199,7 +199,7 @@
 	<key>YandexRadio</key>
 	<integer>2</integer>
 	<key>Youtube</key>
-	<integer>2</integer>
+	<integer>3</integer>
 	<key>Zing</key>
 	<integer>1</integer>
 	<key>Zvooq</key>


### PR DESCRIPTION
Call functions directly on #movie_player instead of (the now removed) player_ instance.

Fixes https://github.com/beardedspice/beardedspice/issues/787