### PR TITLE
fix: pause() in MediaStrategies for Yandex Services

### DIFF
--- a/BeardedSpice/MediaStrategies/YandexMusic.js
+++ b/BeardedSpice/MediaStrategies/YandexMusic.js
@@ -4,10 +4,11 @@
 //
 //  Created by Vladimir Burdukov on 3/14/14.
 //  Updated by Ivan Tsyganov     on 2/13/18.
+//  Updated by Arseny Mitin      on 11/18/18.
 //  Copyright (c) 2014 Tyler Rhodes / Jose Falcon. All rights reserved.
 
 BSStrategy = {
-  version:3,
+  version:4,
   displayName:"YandexMusic",
   accepts: {
     method: "predicateOnTab",
@@ -19,8 +20,9 @@ BSStrategy = {
   next: function () {externalAPI.next();},
   favorite: function () {externalAPI.toggleLike();},
   previous: function () {externalAPI.prev();},
-  pause: function () {externalAPI.togglePause();},
-  
+  pause: function () {
+    if (self.isPlaying()){externalAPI.togglePause();}
+  },
   trackInfo: function () {
     return {
       track:  externalAPI.getCurrentTrack().title,

--- a/BeardedSpice/MediaStrategies/YandexRadio.js
+++ b/BeardedSpice/MediaStrategies/YandexRadio.js
@@ -4,10 +4,11 @@
 //
 //  Created by Leonid Ponomarev 15.06.15
 //  Updated by Ivan Tsyganov    13.02.18
+//  Updated by Arseny Mitin     18.11.18
 //  Copyright (c) 2014 Tyler Rhodes / Jose Falcon. All rights reserved.
 
 BSStrategy = {
-  version:3,
+  version:4,
   displayName:"YandexRadio",
   accepts: {
     method: "predicateOnTab",
@@ -19,8 +20,9 @@ BSStrategy = {
   next: function () {externalAPI.next();},
   favorite: function () {externalAPI.toggleLike();},
   previous: function () {},
-  pause: function () {externalAPI.togglePause();},
-  
+  pause: function () {
+    if (self.isPlaying()){externalAPI.togglePause();}
+  },
   trackInfo: function () {
     return {
       track:  externalAPI.getCurrentTrack().title,

--- a/BeardedSpice/MediaStrategies/versions.plist
+++ b/BeardedSpice/MediaStrategies/versions.plist
@@ -195,9 +195,9 @@
 	<key>Xiami</key>
 	<integer>1</integer>
 	<key>YandexMusic</key>
-	<integer>3</integer>
+	<integer>4</integer>
 	<key>YandexRadio</key>
-	<integer>3</integer>
+	<integer>4</integer>
 	<key>Youtube</key>
 	<integer>3</integer>
 	<key>Zing</key>


### PR DESCRIPTION
On closing the lid of laptop and some other events `pause()` method is called. So if it only toggles play/pause and if I have already paused the track, when I'll close the lid, it will resume playing. The fix is to check if current song is playing at the moment, and then stop it. This is the only way to do it since Yandex's `externalAPI` does not provide separate methods like `play()` and `pause()`.