### PR TITLE
Anghami selectors updated to work

### DIFF
--- a/BeardedSpice/MediaStrategies/Anghami.js
+++ b/BeardedSpice/MediaStrategies/Anghami.js
@@ -21,16 +21,16 @@ BSStrategy = {
         $(".p-sub-item.playpause").click();
     },
     next: function () {
-        $('.p-sub-item.next').click();
+        $(".p-sub-item.next").click();
     },
     favorite: function () {
         $(".p-item.action.like").click();
     },
     previous: function () {
-        $('.p-sub-item.previous').click();
+        $(".p-sub-item.previous").click();
     },
     pause: function () {
-        $('.p-sub-item.play .icon-pause-2").click();
+        $(".p-sub-item.play .icon-pause-2").click();
     },
     trackInfo: function () {
         return {

--- a/BeardedSpice/MediaStrategies/Anghami.js
+++ b/BeardedSpice/MediaStrategies/Anghami.js
@@ -2,7 +2,8 @@
 //  Anghami.js
 //  BeardedSpice
 //
-//  Created by Raja Baz on 08/24/2016.
+//  Created by Raja Baz on 08/24/2016. 
+//  Updated by Yasser El-Sayed on 26/12/2018.
 //
 
 BSStrategy = {
@@ -14,28 +15,28 @@ BSStrategy = {
         args: ["URL"]
     },
     isPlaying: function () {
-        return ($(".action.play .icon-pause").length + $(".action.play .loader").length) > 0;
+        return ($(".p-sub-item.playpause .icon-pause-2").length + $(".p-sub-item.playpause .loader").length) > 0;
     },
     toggle: function () {
-        $(".action.play").click();
+        $(".p-sub-item.playpause").click();
     },
     next: function () {
-        $('.action.next').click();
+        $('.p-sub-item.next').click();
     },
     favorite: function () {
-        $(".action.extras .icon-like").click();
+        $(".p-item.action.like").click();
     },
     previous: function () {
-        $('.action.previous').click();
+        $('.p-sub-item.previous').click();
     },
     pause: function () {
-        $(".action.play .icon-pause").click();
+        $('.p-sub-item.play .icon-pause-2").click();
     },
     trackInfo: function () {
         return {
-            'track': $("a.track-title").text(),
+            'track': $(".track-title a").text(),
             'artist': $("a.track-artist").text(),
-            'image': $(".cover-art img")[0].src,
+            'image': $(".cover-art img").attr('src'),
         };
     }
 }

--- a/BeardedSpice/MediaStrategies/Anghami.js
+++ b/BeardedSpice/MediaStrategies/Anghami.js
@@ -15,7 +15,7 @@ BSStrategy = {
         args: ["URL"]
     },
     isPlaying: function () {
-        return ($(".p-sub-item.playpause .icon-pause-2").length + $(".p-sub-item.playpause .loader").length) > 0;
+        return ($(".p-sub-item.playpause .icon-pause-2").length + $(".p-sub-item.playpause .buffering").length) > 0;
     },
     toggle: function () {
         $(".p-sub-item.playpause").click();


### PR DESCRIPTION
You guys have support for Anghami but they updated their website. @raja-baz very graciously made the #474 PR however this doesn't work anymore as the classes that were being invoked on `.click()` are now outdated (I used them on the console and they didn't work).

In short, `$(".action.play").length` returns `0`.
It should be changed from `$(".action.play").click()` to `$(".p-sub-item.playpause").click()` and similarly for all the others.

I made all the changes, let me know if you have any questions.