### PR TITLE
Add Plexamp for default Media Key Usage

### DIFF
--- a/BeardedSpiceControllers/Controllers/SPMediaKeyTap/SPMediaKeyTap.m
+++ b/BeardedSpiceControllers/Controllers/SPMediaKeyTap/SPMediaKeyTap.m
@@ -134,6 +134,7 @@ static CGEventRef tapEventCallback(CGEventTapProxy proxy, CGEventType type, CGEv
            @"org.videolan.vlc",
            @"com.apple.Aperture",
            @"com.plexsquared.Plex",
+           @"tv.plex.plexamp",
            @"com.soundcloud.desktop",
            @"org.niltsh.MPlayerX",
            @"com.ilabs.PandorasHelper",


### PR DESCRIPTION
Currently Beardedspice would interfere with the media keys in a way that would break [Plexamp](https://plexamp.com)'s native implementation.